### PR TITLE
Update supported Django versions to include 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Support for Django 3.0
+- Support for Python 3.8
+
 ## [0.2.5] - 2019-11-01
 ### Added
 - Switch to Poetry for dependency management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,13 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Framework :: Django",
     "Framework :: Django :: 1.11",
     "Framework :: Django :: 2.0",
     "Framework :: Django :: 2.1",
     "Framework :: Django :: 2.2",
+    "Framework :: Django :: 3.0",
 ]
 packages = [
     { include = "pattern_library" },
@@ -35,7 +37,7 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-Django = ">=1.11,<3"
+Django = ">=1.11,<3.1"
 PyYAML = "^5.1"
 Markdown = "^3.1"
 


### PR DESCRIPTION
## Description

Add Django 3.0 to the pyproject.toml supported Django versions. The tests are already passing against Django 3.0, this is just a packaging update.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
