### PR TITLE
Attempt to fix xframeoption issue

### DIFF
--- a/pattern_library/views.py
+++ b/pattern_library/views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.template.loader import get_template
 from django.utils.html import escape
+from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 
@@ -59,7 +60,7 @@ class RenderPatternView(TemplateView):
     http_method_names = ('get',)
     template_name = get_pattern_base_template_name()
 
-    @xframe_options_sameorigin
+    @method_decorator(xframe_options_sameorigin)
     def get(self, request, pattern_template_name=None):
         try:
             rendered_pattern = render_pattern(request, pattern_template_name)

--- a/pattern_library/views.py
+++ b/pattern_library/views.py
@@ -1,9 +1,9 @@
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.template.loader import get_template
-from django.utils.html import escape
 from django.utils.decorators import method_decorator
-from django.views.generic.base import TemplateView
+from django.utils.html import escape
 from django.views.decorators.clickjacking import xframe_options_sameorigin
+from django.views.generic.base import TemplateView
 
 from pattern_library import get_pattern_base_template_name, get_pattern_types
 from pattern_library.exceptions import (

--- a/pattern_library/views.py
+++ b/pattern_library/views.py
@@ -2,6 +2,7 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.template.loader import get_template
 from django.utils.html import escape
 from django.views.generic.base import TemplateView
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 
 from pattern_library import get_pattern_base_template_name, get_pattern_types
 from pattern_library.exceptions import (
@@ -58,6 +59,7 @@ class RenderPatternView(TemplateView):
     http_method_names = ('get',)
     template_name = get_pattern_base_template_name()
 
+    @xframe_options_sameorigin
     def get(self, request, pattern_template_name=None):
         try:
             rendered_pattern = render_pattern(request, pattern_template_name)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -39,3 +39,13 @@ TEMPLATES = [
         },
     },
 ]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]


### PR DESCRIPTION
## Description

Attempt to fix an issue when running django-pattern-library with django 3. The new default header for X-Frame-Options is 'deny', and we need it to be 'same origin' for the iframe of the pattern to load.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
