### PR TITLE
Add documentation on pattern context customisation in base template

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,28 @@ You can define a list or a dict or anything that
 [`PyYAML`](http://pyyaml.org/wiki/PyYAMLDocumentation)
 allows you to create in `yaml` format without creating a custom objects.
 
+## Customising the patterns’ surroundings
+
+All patterns that are not pages are rendered within a base page template, `pages/base.html` by default. The pattern library will render patterns inside the `content` block, which you can tweak to change how patterns are displayed.
+
+You can for example add a theme wrapper around the components:
+
+```html
+{% block content %}
+    {% if pattern_library_rendered_pattern %}
+        <div class="pattern-library bg bg--light">
+            {{ pattern_library_rendered_pattern }}
+        </div>
+    {% endif %}
+{% endblock %}
+```
+
+`pattern_library_rendered_pattern` can also be used to do other modifications on the page for the pattern library only, for example adding an extra class to `<body>`:
+
+```html
+<body class="{% block body_class %}{% endblock %}{% if pattern_library_rendered_pattern %} pattern-library-template{% endif %}">
+```
+
 ## Override template tags
 
 The package overrides the following Django tags:


### PR DESCRIPTION
Documents how to edit the base template to make it display differently for pattern library components only. This was mentioned on Slack by @nicklee. Also goes some of the way towards #86.

## Type of change

Documentation only.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
