### PR TITLE
Permit variable template names in extends and include tags

### DIFF
--- a/pattern_library/loader_tags.py
+++ b/pattern_library/loader_tags.py
@@ -17,7 +17,7 @@ class ExtendsNode(DjangoExtendsNode):
     """
     def render(self, context):
         if is_pattern_library_context(context):
-            parent_context = get_pattern_context(self.parent_name.var)
+            parent_context = get_pattern_context(self.parent_name.resolve(context))
             if parent_context:
                 # We want parent_context to appear later in the lookup process
                 # than context of the actual template.
@@ -59,7 +59,7 @@ class IncludeNode(DjangoIncludeNode):
     """
     def render(self, context):
         if is_pattern_library_context(context):
-            pattern_context = get_pattern_context(self.template.var)
+            pattern_context = get_pattern_context(self.template.resolve(context))
             extra_context = {name: var.resolve(context) for name, var in self.extra_context.items()}
 
             if self.isolated_context:


### PR DESCRIPTION
## Description

This permits the use of an extends tag

```html
{% extends foo %}
```

or an include tag

```html
{% include foo %}
```

where the context defines `foo`.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
