### PR TITLE
Fix broken page/fragment detection

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,4 @@ Fixes # (issue)
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
+- [ ] I have added an appropriate CHANGELOG entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Pages and fragments are now handled correctly again ([#119](https://github.com/torchbox/django-pattern-library/issues/119))
 - PyPI package metadata now uses absolute URLs to GitHub ([#120](https://github.com/torchbox/django-pattern-library/issues/120)).
 
 ## [0.2.9] - 2020-07-29
@@ -57,3 +58,8 @@
 
 ### Added
 - Compatibility with Django 2.2
+
+[0.2.9]: https://github.com/torchbox/django-pattern-library/releases/tag/v0.2.9
+[0.2.8]: https://github.com/torchbox/django-pattern-library/releases/tag/v0.2.8
+[0.2.5]: https://github.com/torchbox/django-pattern-library/releases/tag/v0.2.5
+[0.2.4]: https://github.com/torchbox/django-pattern-library/releases/tag/v0.2.4

--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 [![PyPI](https://img.shields.io/pypi/v/django-pattern-library.svg)](https://pypi.org/project/django-pattern-library/) [![PyPI downloads](https://img.shields.io/pypi/dm/django-pattern-library.svg)](https://pypi.org/project/django-pattern-library/) [![Travis](https://travis-ci.com/torchbox/django-pattern-library.svg?branch=master)](https://travis-ci.com/torchbox/django-pattern-library) [![Total alerts](https://img.shields.io/lgtm/alerts/g/torchbox/django-pattern-library.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/torchbox/django-pattern-library/alerts/)
 
-A module for Django that helps you to build pattern libraries and follow the
-[Atomic design](http://bradfrost.com/blog/post/atomic-web-design/) methodology.
+A module for Django that helps you to build pattern libraries.
 
 ![Screenshot of the pattern library UI, with navigation, pattern rendering, and configuration](https://raw.githubusercontent.com/torchbox/django-pattern-library/master/.github/pattern-library-screenshot.webp)
 
 ## Documentation
 
-Documentation is located in GitHub in [`docs/`](https://github.com/torchbox/django-pattern-library/tree/master/docs).
+Documentation is located on GitHub in [`docs/`](https://github.com/torchbox/django-pattern-library/tree/master/docs).
 
 ## Objective
 
@@ -29,9 +28,38 @@ To learn more about how this package can be used, have a look at our Wagtail Spa
 
 [![Reusable UI components: A journey from React to Wagtail](https://raw.githubusercontent.com/torchbox/django-pattern-library/master/.github/pattern-library-talk-youtube.webp)](https://www.youtube.com/watch?v=isrOufI7TKc)
 
+## Concepts
+To understand how `django-pattern-library` works, the following concepts are important.
+
+### Patterns
+Any template that is displayed by the pattern library is referred to as a pattern. Patterns are divided into two categories: fragments and pages.
+
+### Fragments
+A fragment is a pattern whose markup does not include all of the resources (typically CSS and Javascript) for it to be displayed correctly on its own. This is typical for reusable component templates which depend on global stylesheets or Javascript bundles to render and behave correctly.
+
+To enable them to be correctly displayed in the pattern library, `django-pattern-library` will inject the rendered markup of fragments into the **pattern base template** specified by `PATTERN_LIBRARY['PATTERN_BASE_TEMPLATE_NAME']`.
+
+This template should include references to any required static files. The rendered markup of fragments will be available in the `pattern_library_rendered_pattern` context variable (see the tests for [an example](https://github.com/torchbox/django-pattern-library/blob/master/tests/templates/patterns/base.html)).
+
+### Pages
+In contrast to fragments, pages are patterns that include everything they need to be displayed correctly in their markup. Pages are defined by `PATTERN_LIBRARY['BASE_TEMPLATE_NAMES']`. 
+
+Any template in that list — or that extends a template in that list — is considered a page and will be displayed as-is when rendered in the pattern library.
+
+It is common practice for page templates to extend the pattern base template to avoid duplicate references to stylesheets and Javascript bundles. Again, [an example](https://github.com/torchbox/django-pattern-library/blob/master/tests/templates/patterns/base_page.html) of this can be seen in the tests.
+
 ## How to install
 
-In your Django settings, add `pattern_library` into your `INSTALLED_APPS`, and `pattern_library.loader_tags` into the `TEMPLATES` setting. For example:
+First install the library:
+
+```sh
+pip install django-pattern-library
+# ... or...
+poetry add django-pattern-library
+```
+
+
+Then, in your Django settings, add `pattern_library` into your `INSTALLED_APPS`, and `pattern_library.loader_tags` to `OPTIONS['builtins']` into the `TEMPLATES` setting. For example:
 
 ```python
 INSTALLED_APPS = [
@@ -58,18 +86,42 @@ TEMPLATES = [
 ]
 ```
 
-Note that this module only supports the Django template backend out of the box.
+Note that this module only supports the Django template backend.
 
-Set the `PATTERN_LIBRARY_TEMPLATE_DIR` setting to point to a template directory with your patterns:
+### Settings
+
+Next, set the `PATTERN_LIBRARY` setting. Here's an example showing the defaults:
 
 ```python
-PATTERN_LIBRARY_TEMPLATE_DIR = os.path.join(BASE_DIR, 'project_styleguide', 'templates')
+PATTERN_LIBRARY = {
+    # PATTERN_BASE_TEMPLATE_NAME is the template that fragments will be wrapped with.
+    # It should include any required CSS and JS and output
+    # `pattern_library_rendered_pattern` from context.
+    'PATTERN_BASE_TEMPLATE_NAME': 'patterns/base.html',
+    # Any template in BASE_TEMPLATE_NAMES or any template that extends a template in
+    # BASE_TEMPLATE_NAMES is a "page" and will be rendered as-is without being wrapped.
+    'BASE_TEMPLATE_NAMES': ['patterns/base_page.html'],
+    'TEMPLATE_SUFFIX': '.html',
+    # SECTIONS controls the groups of templates that appear in the navigation. The keys
+    # are the group titles and the values are lists of template name prefixes that will
+    # be searched to populate the groups.
+    'SECTIONS': (
+        ('atoms', ['patterns/atoms']),
+        ('molecules', ['patterns/molecules']),
+        ('organisms', ['patterns/organisms']),
+        ('templates', ['patterns/templates']),
+        ('pages', ['patterns/pages']),
+    ),
+}
+
 ```
 
-Note that `PATTERN_LIBRARY_TEMPLATE_DIR` must be available for
-[template loaders](https://docs.djangoproject.com/en/1.11/ref/templates/api/#loader-types).
+Note that the templates in your `PATTERN_LIBRARY` settings must be available to your project's
+[template loaders](https://docs.djangoproject.com/en/3.1/ref/templates/api/#loader-types).
 
-Include `pattern_library.urls` into your `urlpatterns`. Here's an example `urls.py`:
+### URLs
+
+Include `pattern_library.urls` in your `urlpatterns`. Here's an example `urls.py`:
 
 ```python
 from django.apps import apps

--- a/pattern_library/__init__.py
+++ b/pattern_library/__init__.py
@@ -1,10 +1,17 @@
-
-
 default_app_config = 'pattern_library.apps.PatternLibraryAppConfig'
 
 DEFAULT_SETTINGS = {
-    'BASE_TEMPLATE_NAME': 'patterns/base.html',
+    # PATTERN_BASE_TEMPLATE_NAME is the template that fragments will be wrapped with.
+    # It should include any required CSS and JS and output
+    # `pattern_library_rendered_pattern` from context.
+    'PATTERN_BASE_TEMPLATE_NAME': 'patterns/base.html',
+    # Any template in BASE_TEMPLATE_NAMES or any template that extends a template in
+    # BASE_TEMPLATE_NAMES is a "page" and will be rendered as-is without being wrapped.
+    'BASE_TEMPLATE_NAMES': ['patterns/base_page.html'],
     'TEMPLATE_SUFFIX': '.html',
+    # SECTIONS controls the groups of templates that appear in the navigation. The keys
+    # are the group titles and the value are lists of template name prefixes that will
+    # be searched to populate the groups.
     'SECTIONS': (
         ('atoms', ['patterns/atoms']),
         ('molecules', ['patterns/molecules']),
@@ -15,25 +22,27 @@ DEFAULT_SETTINGS = {
 }
 
 
-def get_from_settings(attr):
+def get_setting(attr):
     from django.conf import settings
-
     library_settings = DEFAULT_SETTINGS.copy()
     library_settings.update(getattr(settings, 'PATTERN_LIBRARY', {}))
-
     return library_settings.get(attr)
 
 
 def get_pattern_template_suffix():
-    return get_from_settings('TEMPLATE_SUFFIX')
+    return get_setting('TEMPLATE_SUFFIX')
 
 
 def get_pattern_base_template_name():
-    return get_from_settings('BASE_TEMPLATE_NAME')
+    return get_setting('PATTERN_BASE_TEMPLATE_NAME')
+
+
+def get_base_template_names():
+    return get_setting('BASE_TEMPLATE_NAMES')
 
 
 def get_sections():
-    return get_from_settings('SECTIONS')
+    return get_setting('SECTIONS')
 
 
 def get_pattern_context_var_name():

--- a/pattern_library/loader_tags.py
+++ b/pattern_library/loader_tags.py
@@ -17,7 +17,8 @@ class ExtendsNode(DjangoExtendsNode):
     """
     def render(self, context):
         if is_pattern_library_context(context):
-            parent_context = get_pattern_context(self.parent_name.var)
+            parent_name = self.parent_name.resolve(context)
+            parent_context = get_pattern_context(parent_name)
             if parent_context:
                 # We want parent_context to appear later in the lookup process
                 # than context of the actual template.
@@ -59,7 +60,8 @@ class IncludeNode(DjangoIncludeNode):
     """
     def render(self, context):
         if is_pattern_library_context(context):
-            pattern_context = get_pattern_context(self.template.var)
+            template = self.template.resolve(context)
+            pattern_context = get_pattern_context(template)
             extra_context = {name: var.resolve(context) for name, var in self.extra_context.items()}
 
             if self.isolated_context:
@@ -89,8 +91,8 @@ class IncludeNode(DjangoIncludeNode):
 @register.tag('extends')
 def do_extends(parser, token):
     """
-    Copy if Django's built-in {% extends ... %} tag that uses the custom
-    ExtendsNode to allow us to load dump data for pattern library.
+    A copy of Django's built-in {% extends ... %} tag that uses our custom
+    ExtendsNode to allow us to load dummy context for the pattern library.
     """
     bits = token.split_contents()
     if len(bits) != 2:
@@ -106,8 +108,8 @@ def do_extends(parser, token):
 @register.tag('include')
 def do_include(parser, token):
     """
-    Copy if Django's built-in {% include ... %} tag that uses the custom
-    IncludeNode to allow us to load dump data for pattern library.
+    A copy of Django's built-in {% include ... %} tag that uses our custom
+    IncludeNode to allow us to load dummy context for the pattern library.
     """
     bits = token.split_contents()
     if len(bits) < 2:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,6 +24,7 @@ PATTERN_LIBRARY = {
     'SECTIONS': [
         ('atoms', ['patterns/atoms']),
         ('molecules', ['patterns/molecules']),
+        ('pages', ['patterns/pages']),
     ],
 }
 

--- a/tests/templates/non-patterns/variable_include.html
+++ b/tests/templates/non-patterns/variable_include.html
@@ -1,0 +1,1 @@
+included content from variable

--- a/tests/templates/patterns/atoms/test_extends/base.html
+++ b/tests/templates/patterns/atoms/test_extends/base.html
@@ -1,0 +1,1 @@
+{% block content %}base content{% endblock %}

--- a/tests/templates/patterns/atoms/test_extends/extended.html
+++ b/tests/templates/patterns/atoms/test_extends/extended.html
@@ -1,0 +1,3 @@
+{% extends parent_template_name %}
+
+{% block content %}{{ block.super }} - extended content{% endblock %}

--- a/tests/templates/patterns/atoms/test_extends/extended.yaml
+++ b/tests/templates/patterns/atoms/test_extends/extended.yaml
@@ -1,0 +1,2 @@
+context:
+    parent_template_name: patterns/atoms/test_extends/base.html

--- a/tests/templates/patterns/atoms/test_includes/test_includes.html
+++ b/tests/templates/patterns/atoms/test_includes/test_includes.html
@@ -1,5 +1,6 @@
 {% load test_tags %}
 
 {% include 'non-patterns/include.html' %}
+{% include variable_include %}
 
 {% error_tag include %}

--- a/tests/templates/patterns/atoms/test_includes/test_includes.yaml
+++ b/tests/templates/patterns/atoms/test_includes/test_includes.yaml
@@ -1,3 +1,6 @@
+context:
+    variable_include: non-patterns/variable_include.html
+
 tags:
   error_tag:
     include:

--- a/tests/templates/patterns/base.html
+++ b/tests/templates/patterns/base.html
@@ -1,1 +1,8 @@
-{% block content %}{{ pattern_library_rendered_pattern }}{% endblock %}
+<html lang="en-GB">
+    <head>
+        <title>{% block title %}Fragment{% endblock %}</title>
+    </head>
+    <body>
+        {% block content %}{{ pattern_library_rendered_pattern }}{% endblock %}
+    </body>
+</html>

--- a/tests/templates/patterns/base_page.html
+++ b/tests/templates/patterns/base_page.html
@@ -1,0 +1,3 @@
+{% extends 'patterns/base.html' %}
+
+{% block title %}Page{% endblock %}

--- a/tests/templates/patterns/pages/test_page/test_page.html
+++ b/tests/templates/patterns/pages/test_page/test_page.html
@@ -1,0 +1,3 @@
+{% extends 'patterns/base_page.html' %}
+
+{% block content %}{{ page.body }}{% endblock %}

--- a/tests/templates/patterns/pages/test_page/test_page.yaml
+++ b/tests/templates/patterns/pages/test_page/test_page.yaml
@@ -1,0 +1,11 @@
+context:
+    page:
+        body: >
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+                quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+                cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -1,0 +1,35 @@
+from django.test import SimpleTestCase
+
+from pattern_library.utils import get_template_ancestors
+
+
+class TestGetTemplateAncestors(SimpleTestCase):
+    def test_page(self):
+        self.assertEqual(
+            get_template_ancestors('patterns/pages/test_page/test_page.html'),
+            [
+                'patterns/pages/test_page/test_page.html',
+                'patterns/base_page.html',
+                'patterns/base.html',
+            ],
+        )
+
+    def test_fragment(self):
+        self.assertEqual(
+            get_template_ancestors('patterns/atoms/test_atom/test_atom.html'),
+            [
+                'patterns/atoms/test_atom/test_atom.html',
+            ],
+        )
+
+    def test_parent_template_from_variable(self):
+        self.assertEqual(
+            get_template_ancestors(
+                'patterns/atoms/test_extends/extended.html',
+                context={'parent_template_name': 'patterns/base.html'},
+            ),
+            [
+                'patterns/atoms/test_extends/extended.html',
+                'patterns/base.html',
+            ],
+        )

--- a/tests/tests/test_views.py
+++ b/tests/tests/test_views.py
@@ -71,3 +71,40 @@ class ViewsTestCase(SimpleTestCase):
         self.assertEqual(render_response.status_code, 200)
         self.assertContains(render_response, 'SHOWME')
         self.assertNotContains(render_response, 'HIDEME')
+        self.assertContains(render_response, 'included content from variable')
+
+    def test_page(self):
+        test_page_render_url = reverse(
+            'pattern_library:render_pattern',
+            kwargs={'pattern_template_name': "patterns/pages/test_page/test_page.html"},
+        )
+        response = self.client.get(test_page_render_url)
+
+        self.assertContains(response, '<title>Page</title>')
+
+    def test_fragments(self):
+        for template_name in [
+            'patterns/atoms/test_atom/test_atom.html',
+            'patterns/molecules/test_molecule/test_molecule.html',
+        ]:
+            with self.subTest(template_name=template_name):
+                self.assertContains(
+                    self.client.get(
+                        reverse(
+                            'pattern_library:render_pattern',
+                            kwargs={'pattern_template_name': template_name},
+                        ),
+                    ),
+                    '<title>Fragment</title>',
+                )
+
+    def test_fragment_extended_from_variable(self):
+        self.assertContains(
+            self.client.get(
+                reverse(
+                    'pattern_library:render_pattern',
+                    kwargs={'pattern_template_name': "patterns/atoms/test_extends/extended.html"},
+                ),
+            ),
+            'base content - extended content',
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}-dj{22,30,31}, lint
+envlist = py{36,37,38}-dj{22,30,31,master}, lint
 skipsdist = true
 
 [testenv]
@@ -13,6 +13,7 @@ deps =
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
+    djmaster: https://github.com/django/django/archive/master.zip
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
## Description

Fixes #119 

This fixes an issue that was introduced by #83 where the removal of a specific "pages" pattern type broke the logic that chooses whether or not to wrap the rendered output of a pattern in the base pattern template or not. After that change, all rendered patterns were wrapped in the base template, causing patterns whose template extended the base template already to duplicate that code (e.g. `<head>` content).

This PR fixes that by doing a few things: 

- Adding a new setting `PATTERN_LIBRARY['BASE_TEMPLATE_NAMES']` that replaces the old `PATTERN_LIBRARY_BASE_TEMPLATE_NAME`
- Adding a utility function that returns the extension hierarchy of a given template
- Using that utility function to check whether a pattern extends on of the base templates (i.e. does not need wrapping in the base pattern template) or does not extend those templates (i.e. _does_ need wrapping in the base pattern template) and returns the appropriate rendered result.

Other bits:
- I've included the fix from #112 where we weren't handling variable names passed to `{% extends %}` or `{% include %}` tags
- I've added Django master to the list of tested versions as this has been requested elsewhere and I might as well (it passes, woo!)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have made corresponding changes to the documentation
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
