### PR TITLE
Implement optional default for override_tag

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -146,6 +146,9 @@ override_tag(register, 'a_tag_name', default="https://potato.com")
 
 This default is used for any tag that's not passed its own context, allowing specificity for those elements that need it while preventing the tag from breaking when it's not structural to the component.
 
+#### limitation
+Currently the default override is limited to direct references only i.e. {% a_tag_name page.url %} and not {% a_tag_name page.url as variable_name %} 
+
 ### When do I need to override a template tag?
 
 Ideally your pattern library should be independent, so it doesn't fail when

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -144,8 +144,7 @@ from pattern_library.monkey_utils import override_tag
 override_tag(register, 'a_tag_name', default="https://potato.com")
 ```
 
-This default is used for any tag that's not passed it's own context allowing specificity for certain elements that need it but stops the tags breaking when they're not structural to the component.
-
+This default is used for any tag that's not passed its own context, allowing specificity for those elements that need it while preventing the tag from breaking when it's not structural to the component.
 
 ### When do I need to override a template tag?
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -136,19 +136,18 @@ The override process has two parts:
 
 
 ### Providing a default value for template tags
-To provide a default for a template tag, you need to provide a keyword argument default when overriding your tag.
+To provide a default for a template tag, you need to provide a keyword argument default_html when overriding your tag.
 
 ```
 from pattern_library.monkey_utils import override_tag
 
-override_tag(register, 'a_tag_name', default="https://potato.com")
+override_tag(register, 'a_tag_name', default_html="https://potato.com")
 ```
 
 This default is used for any tag that's not passed its own context, allowing specificity for those elements that need it while preventing the tag from breaking when it's not structural to the component.
 
-#### limitation
-Currently the default override is limited to direct references only i.e. {% a_tag_name page.url %} and not {% a_tag_name page.url as variable_name %} 
-
+#### Limitation
+Currently this feature only supports providing a default for the output of the tag, this does not support modifying context in templates such as {% an_example_tag page.url as example_variable %}.
 ### When do I need to override a template tag?
 
 Ideally your pattern library should be independent, so it doesn't fail when

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -134,6 +134,19 @@ The override process has two parts:
 1.  Override your template tag with a mock implementation
 2.  Define fake result for your tag in a `yaml` file
 
+
+### Providing a default value for template tags
+To provide a default for a template tag, you need to provide a keyword argument default when overriding your tag.
+
+```
+from pattern_library.monkey_utils import override_tag
+
+override_tag(register, 'a_tag_name', default="https://potato.com")
+```
+
+This default is used for any tag that's not passed it's own context allowing specificity for certain elements that need it but stops the tags breaking when they're not structural to the component.
+
+
 ### When do I need to override a template tag?
 
 Ideally your pattern library should be independent, so it doesn't fail when

--- a/pattern_library/monkey_utils.py
+++ b/pattern_library/monkey_utils.py
@@ -7,9 +7,10 @@ from pattern_library.utils import (
 )
 
 logger = logging.getLogger(__name__)
+UNSPECIFIED = object()
 
 
-def override_tag(register, name, default=None):
+def override_tag(register, name, default_html=None):
     """
     An utility that helps you override original tags for use in your pattern library.
 
@@ -53,7 +54,7 @@ def override_tag(register, name, default=None):
                         request = context.get('request')
                         result = render_pattern(request, template_name, allow_non_patterns=True)
                         tag_overridden = True
-                    
+
                     # TODO: Allow objects with the __str__ method
                     # In some cases we must return an object that can
                     # be rendered as a string `{{ result }}`
@@ -75,12 +76,11 @@ def override_tag(register, name, default=None):
 
                     # Render result instead of the tag
                     return result
+                elif default_html is not UNSPECIFIED:
+                    # Render provided default;
+                    # if no stub data supplied.
+                    return default_html
                 else:
-                    if default:
-                        # Render provided default;
-                        # if no stub data supplied.
-                        return default
-
                     logger.warning(
                         'No default or stub data defined for the "%s" tag in the "%s" template',
                         tag_name, current_template_name

--- a/pattern_library/monkey_utils.py
+++ b/pattern_library/monkey_utils.py
@@ -9,7 +9,7 @@ from pattern_library.utils import (
 logger = logging.getLogger(__name__)
 
 
-def override_tag(register, name):
+def override_tag(register, name, default=None):
     """
     An utility that helps you override original tags for use in your pattern library.
 
@@ -53,7 +53,7 @@ def override_tag(register, name):
                         request = context.get('request')
                         result = render_pattern(request, template_name, allow_non_patterns=True)
                         tag_overridden = True
-
+                    
                     # TODO: Allow objects with the __str__ method
                     # In some cases we must return an object that can
                     # be rendered as a string `{{ result }}`
@@ -76,8 +76,13 @@ def override_tag(register, name):
                     # Render result instead of the tag
                     return result
                 else:
+                    if default:
+                        # Render provided default;
+                        # if no stub data supplied.
+                        return default
+
                     logger.warning(
-                        'No stub data defined for the "%s" tag in the "%s" template',
+                        'No default or stub data defined for the "%s" tag in the "%s" template',
                         tag_name, current_template_name
                     )
 

--- a/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.html
+++ b/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.html
@@ -3,3 +3,7 @@
 SAND{% error_tag empty_string %}WICH
 SAND{% error_tag none %}WICH
 SAND{% error_tag zero %}WICH
+
+POTA{% default_tag page.url %}TO 
+POTA{% default_tag page.child.url %}TO
+POTA{% default_tag None %}TO

--- a/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.html
+++ b/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.html
@@ -8,6 +8,6 @@ POTA{% default_html_tag page.url %}TO
 POTA{% default_html_tag page.child.url %}TO
 POTA{% default_html_tag None %}TO
 
-POTA{% default_html_tag page.url %}TO1
-POTA{% default_html_tag page.child.url %}TO2
-POTA{% default_html_tag %}TO3
+POTA{% default_html_tag_falsey empty_string %}TO1
+POTA{% default_html_tag_falsey none %}TO2
+POTA{% default_html_tag_falsey zero %}TO3

--- a/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.html
+++ b/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.html
@@ -4,6 +4,10 @@ SAND{% error_tag empty_string %}WICH
 SAND{% error_tag none %}WICH
 SAND{% error_tag zero %}WICH
 
-POTA{% default_tag page.url %}TO 
-POTA{% default_tag page.child.url %}TO
-POTA{% default_tag None %}TO
+POTA{% default_html_tag page.url %}TO 
+POTA{% default_html_tag page.child.url %}TO
+POTA{% default_html_tag None %}TO
+
+POTA{% default_html_tag page.url %}TO1
+POTA{% default_html_tag page.child.url %}TO2
+POTA{% default_html_tag %}TO3

--- a/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
+++ b/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
@@ -13,8 +13,10 @@ tags:
       raw: "another_example"
     # None handled by default html value.
   default_html_tag_falsey:
-    page.url:
-      raw: "None"
-    page.child.url:
-      raw: "False"
+    empty_string:
+      raw: ''
+    none:
+      raw: null
+    zero:
+      raw: 0
   

--- a/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
+++ b/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
@@ -6,10 +6,15 @@ tags:
       raw: null
     zero:
       raw: 0
-  default_tag:
+  default_html_tag:
     page.url:
       raw: "example"
     page.child.url:
       raw: "another_example"
-    # None supplied by default value.
+    # None handled by default html value.
+  default_html_tag_falsey:
+    page.url:
+      raw: "None"
+    page.child.url:
+      raw: "False"
   

--- a/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
+++ b/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
@@ -6,3 +6,10 @@ tags:
       raw: null
     zero:
       raw: 0
+  default_tag:
+    page.url:
+      raw: "example"
+    page.child.url:
+      raw: "another_example"
+    # None supplied by default value.
+  

--- a/tests/templatetags/test_tags.py
+++ b/tests/templatetags/test_tags.py
@@ -4,18 +4,28 @@ from pattern_library.monkey_utils import override_tag
 
 register = template.Library()
 
+
 # Basic template tag
 @register.simple_tag
 def error_tag(arg=None):
     "Just raise an exception, never do anything"
     raise Exception("error_tag raised an exception")
 
-# Template tag to to test setting a default.
+
+# Template tag to to test setting a default html value.
 @register.simple_tag()
-def default_tag(arg=None):
+def default_html_tag(arg=None):
     "Just raise an exception, never do anything"
     raise Exception("default_tag raised an exception")
 
 
-override_tag(register, 'default_tag', default="https://potato.com")
+# Template tag to to test setting a default html value that is falsey.
+@register.simple_tag()
+def default_html_tag_falsey(arg=None):
+    "Just raise an exception, never do anything"
+    raise Exception("default_tag raised an exception")
+
+
 override_tag(register, 'error_tag')
+override_tag(register, 'default_html_tag', default_html="https://potato.com")
+override_tag(register, 'default_html_tag_falsey', default_html="None")

--- a/tests/templatetags/test_tags.py
+++ b/tests/templatetags/test_tags.py
@@ -28,4 +28,4 @@ def default_html_tag_falsey(arg=None):
 
 override_tag(register, 'error_tag')
 override_tag(register, 'default_html_tag', default_html="https://potato.com")
-override_tag(register, 'default_html_tag_falsey', default_html="None")
+override_tag(register, 'default_html_tag_falsey', default_html=None)

--- a/tests/templatetags/test_tags.py
+++ b/tests/templatetags/test_tags.py
@@ -4,11 +4,18 @@ from pattern_library.monkey_utils import override_tag
 
 register = template.Library()
 
-
+# Basic template tag
 @register.simple_tag
 def error_tag(arg=None):
     "Just raise an exception, never do anything"
     raise Exception("error_tag raised an exception")
 
+# Template tag to to test setting a default.
+@register.simple_tag()
+def default_tag(arg=None):
+    "Just raise an exception, never do anything"
+    raise Exception("default_tag raised an exception")
 
+
+override_tag(register, 'default_tag', default="https://potato.com")
 override_tag(register, 'error_tag')

--- a/tests/tests/test_tags.py
+++ b/tests/tests/test_tags.py
@@ -29,5 +29,5 @@ class TagsTestCase(SimpleTestCase):
             kwargs={'pattern_template_name': 'patterns/atoms/tags_test_atom/tags_test_atom.html'},
         ))
         self.assertContains(response, "POTATO1")
-        self.assertContains(response, "POTATO2")
-        self.assertContains(response, "POTATO3")
+        self.assertContains(response, "POTANoneTO2")
+        self.assertContains(response, "POTA0TO3")

--- a/tests/tests/test_tags.py
+++ b/tests/tests/test_tags.py
@@ -3,7 +3,7 @@ from django.test import SimpleTestCase
 from .utils import reverse
 
 
-class TagsTesCase(SimpleTestCase):
+class TagsTestCase(SimpleTestCase):
     def test_falsey_raw_values_for_tag_output(self):
         response = self.client.get(reverse(
             'pattern_library:render_pattern',
@@ -12,8 +12,8 @@ class TagsTesCase(SimpleTestCase):
         self.assertContains(response, "SANDWICH")
         self.assertContains(response, "SANDNoneWICH")
         self.assertContains(response, "SAND0WICH")
-    
-    def test_default_override(self):
+
+    def test_default_html_override(self):
         response = self.client.get(reverse(
             'pattern_library:render_pattern',
             kwargs={'pattern_template_name': 'patterns/atoms/tags_test_atom/tags_test_atom.html'},
@@ -23,3 +23,11 @@ class TagsTesCase(SimpleTestCase):
         self.assertContains(response, "POTAanother_exampleTO")
         self.assertContains(response, "POTAhttps://potato.comTO")
 
+    def test_falsey_default_html_overide(self):
+        response = self.client.get(reverse(
+            'pattern_library:render_pattern',
+            kwargs={'pattern_template_name': 'patterns/atoms/tags_test_atom/tags_test_atom.html'},
+        ))
+        self.assertContains(response, "POTATO1")
+        self.assertContains(response, "POTATO2")
+        self.assertContains(response, "POTATO3")

--- a/tests/tests/test_tags.py
+++ b/tests/tests/test_tags.py
@@ -12,3 +12,14 @@ class TagsTesCase(SimpleTestCase):
         self.assertContains(response, "SANDWICH")
         self.assertContains(response, "SANDNoneWICH")
         self.assertContains(response, "SAND0WICH")
+    
+    def test_default_override(self):
+        response = self.client.get(reverse(
+            'pattern_library:render_pattern',
+            kwargs={'pattern_template_name': 'patterns/atoms/tags_test_atom/tags_test_atom.html'},
+        ))
+
+        self.assertContains(response, "POTAexampleTO")
+        self.assertContains(response, "POTAanother_exampleTO")
+        self.assertContains(response, "POTAhttps://potato.comTO")
+


### PR DESCRIPTION
## Description
This PR provides away for a template tag to be provided a default value, across any template that is rendered. This default can be overridden in template specific context if desired so still allows for specific functionality when required.

Please include a summary of the changes and which issue this relates to (if applicable). Please list any dependencies that are required for this change.

Fixes # Request from feedback sheet.

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
