### PR TITLE
mkdocs documentation build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ node_modules/
 /build/
 /dist/
 /pattern_library/static/
+site/

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ instance/
 .scrapy
 # Sphinx documentation
 docs/_build/
+# mkdocs documentation
+site
 # PyBuilder
 target/
 # IPython Notebook

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,13 @@ jobs:
       script:
         - cp README.md docs/README.md
         - poetry run mkdocs build
+      deploy:
+        - provider: pages
+          skip_cleanup: true
+          local_dir: build
+          github_token: "$PAGES_GITHUB_API_TOKEN"
+          on:
+            branch: master
 install:
   - pip install poetry tox
 script:
@@ -37,3 +44,8 @@ branches:
     - gh-pages
 notifications:
   email: false
+env:
+  global:
+    # Permissions: public_repo
+    # travis encrypt --pro PAGES_GITHUB_API_TOKEN=<value>
+    - secure: "X2mgTFLOKwPpWqYMtcPxeGduDrXcKZN9Nwg/90TrzZU07+hNTm5nfd4WZxnBK1B/EZLysetBMMtovVxxtI84mYOMnY+gOTp37AlrY79dldz7nRD5R5ECOvMegQ+cndJ4OAvR2eJm4WsHSBMWsxx4a6NdX/jJI4iAg8CxNdPopO8EsjInHtA8ANmUkJKJyVnnUbe/Un4c713rwnB7nbILiKDqCgkZwhsF34e1Ft7oaJ0XKZg2e/h0DNqseSMwp2HDi/Ti5Y4eQlSYHnPshscxRV21EVlhDqNS0opxgyKd14AFSV3bkxmbD8hzn7VEHSVmkL2PHEd3atIqcGa/VwIw4bZWqTPtHR4YqJeKsnBPLPlQOZy3097rtuRVAPs8OuoOOm7OTss0INRFav8fOY5zq3aZqdywQoLZuDbJOpHz7idZyXwuQKUDxsXKncjoR3XoFhqhLxVUvj6zjXWFSRPc5e/+f17zBIQhr0BQJ/IPIRj3yFdnDGElCpBwJLs5KQM0Ay3NLygvZ4yb4b73m0VgdM/oC0aOw99oElimyllbeSSZzRoPzk3PX/gg45acerGNGbZlDQF363xCjqJB4I7c0GlhQW4vGf+rkpFnFfXZqxDMKVlUmGCpV5QITCqcP2U042eF+/zcxj//F7c4kqyLB8Tz1ktwmQEI/Qi7Y4cMuKE="

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
         - poetry install
       script:
         - cp README.md docs/README.md
-        - poetry run mkdocs
+        - poetry run mkdocs build
 install:
   - pip install poetry tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
       deploy:
         - provider: pages
           skip_cleanup: true
-          local_dir: build
+          local_dir: site
           github_token: "$PAGES_GITHUB_API_TOKEN"
           on:
             branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
         - npm run build
     - python: 3.8
       install:
+        - pip install poetry
         - poetry install
       script:
         - cp README.md docs/README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,19 @@ jobs:
         - npm install --no-optional --no-audit --progress=false
       script:
         - npm run build
+    - python: 3.8
+      install:
+        - poetry install
+      script:
+        - cp README.md docs/README.md
+        - poetry run mkdocs
 install:
   - pip install poetry tox
 script:
   - tox -e lint
   - tox -e $(tox -l | grep ${PYVER} | xargs echo | sed 's/ /,/g')
+branches:
+  except:
+    - gh-pages
 notifications:
   email: false

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-As we [already mentioned](../README.md), the main idea of this package is
+The main idea of this package is
 to allow you use template in both: your pattern library and
 production code of your Django project.
 
@@ -193,8 +193,7 @@ Note that the fake implementation will only be used when viewing the
 pattern library: you will be using the actual implementation in
 our production code.
 
-Assuming that you already have
-[module installed in your project](../README.md),
+Assuming that you already have module installed in your project,
 to define a fake implementation we need to:
 
 1.  Create [a `templatetags` package](https://docs.djangoproject.com/en/2.0/howto/custom-template-tags/#code-layout)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,26 @@
+site_name: django-pattern-library
+repo_url: https://github.com/torchbox/django-pattern-library
+site_url:
+edit_uri: edit/master/docs/
+
+repo_name: django-pattern-library
+dev_addr: 0.0.0.0:8001
+theme:
+  name: material
+  font: false
+markdown_extensions:
+  - codehilite
+  - admonition
+  - sane_lists
+  - toc:
+      permalink: true
+  # pymdown-extensions meant to bring the Markdown implementation closer to GFM.
+  - pymdownx.details
+  - pymdownx.magiclink
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+nav:
+  - 'Home': 'README.md'
+  - 'Overview': 'overview.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,5 +22,6 @@ markdown_extensions:
   - pymdownx.tilde
 
 nav:
+  # Auto-magically copied from the root of the project in the CI build.
   - 'Home': 'README.md'
   - 'Overview': 'overview.md'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ beautifulsoup4 = "^4.8"
 coverage = "^4.5"
 flake8 = "^3.7"
 isort = {version = "^4.3", extras = ["pyproject"]}
+mkdocs = "^1.1.2"
+mkdocs-material = "^5.5.14"
+pymdown-extensions = "^8.0"
 
 [tool.isort]
 known_first_party = "pattern_library"


### PR DESCRIPTION
Basic mkdocs setup following what we use on client projects, but with deployment via GitHub Pages on the `gh-pages` branch.