### PR TITLE
Add X_FRAME_OPTIONS to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ PATTERN_LIBRARY_TEMPLATE_DIR = os.path.join(BASE_DIR, 'project_styleguide', 'tem
 Note that `PATTERN_LIBRARY_TEMPLATE_DIR` must be available for
 [template loaders](https://docs.djangoproject.com/en/1.11/ref/templates/api/#loader-types).
 
+For Django 3.0 and up, set the X-Frame-Options response headers:
+
+```python
+X_FRAME_OPTIONS = 'SAMEORIGIN'
+```
+
 Include `pattern_library.urls` into your `urlpatterns`. Here's an example `urls.py`:
 
 ```python


### PR DESCRIPTION
## Description

This PR updates the readme to set `X_FRAME_OPTIONS = 'SAMEORIGIN'` on Django 3.0 and up.

This is because Django switched from 'SAMEORIGIN' to 'DENY' as default.
https://docs.djangoproject.com/en/3.1/releases/3.0/#security

## Checklist
✅ My code follows the style guidelines of this project
✅  I have performed a self-review of my own code
N/A I have commented my code, particularly in hard-to-understand areas
✅   I have made corresponding changes to the documentation
N/A My changes generate no new warnings
N/A I have added tests that prove my fix is effective or that my feature works
✅  New and existing unit tests pass locally with my changes
