### PR TITLE
Declare support for Python 3.9, and tentatively Django 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,21 @@ jobs:
       env: PYVER=py38
     - python: 3.9
       env: PYVER=py39
-    - python: 3.8
+    # Separate job for tasks which should only run once per build.
+    - python: 3.9
       install:
-        - pip install poetry
-        - poetry install
+        - pip install poetry tox
         - nvm install
         - npm install --no-optional --no-audit --progress=false
+        - poetry install
       script:
+        # Python linting.
+        - tox -e lint
+        # Docs website build.
         - poetry run mkdocs build
-        - npm run build
+        # Package build, incl. publishing an experimental pre-release via GitHub Pages for builds on `master`.
         - cat pyproject.toml| awk '{sub(/^version = .+/,"version = \"0.0.0.dev\"")}1' > pyproject.toml.tmp && mv pyproject.toml.tmp pyproject.toml
+        - npm run build
         - poetry build
         - cp -R dist site
       deploy:
@@ -39,7 +44,6 @@ jobs:
 install:
   - pip install poetry tox
 script:
-  - tox -e lint
   - tox -e $(tox -l | grep ${PYVER} | xargs echo | sed 's/ /,/g')
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ cache:
     - node_modules
 jobs:
   include:
-    - env: PYVER=py36
-      python: 3.6
-    - env: PYVER=py37
-      python: 3.7
-    - env: PYVER=py38
-      python: 3.8
+    - python: 3.6
+      env: PYVER=py36
+    - python: 3.7
+      env: PYVER=py37
+    - python: 3.8
+      env: PYVER=py38
+    - python: 3.9
+      env: PYVER=py39
     - python: 3.8
       install:
         - pip install poetry

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ poetry add --dev django-pattern-library
 
 We support:
 
-- Django 2.2.x, 3.0.x, 3.1.x
+- Django 2.2.x, 3.0.x, 3.1.x, 3.2.x (experimental)
 - Python 3.6, 3.7, 3.8
 - Django Templates only, no Jinja support
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ poetry add --dev django-pattern-library
 We support:
 
 - Django 2.2.x, 3.0.x, 3.1.x, 3.2.x (experimental)
-- Python 3.6, 3.7, 3.8
+- Python 3.6, 3.7, 3.8, 3.9
 - Django Templates only, no Jinja support
 
 ## Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Framework :: Django",
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
+    "Framework :: Django :: 3.2",
 ]
 packages = [
     { include = "pattern_library" },
@@ -36,7 +37,7 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-Django = ">=2.2,<3.2"
+Django = ">=2.2,<4.0"
 PyYAML = "^5.1"
 Markdown = "^3.1"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}-dj{22,30,31,master}, lint
+envlist = py{36,37,38,39}-dj{22,30,31,master}, lint
 skipsdist = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 commands =
     poetry install -q
     poetry run flake8
-    poetry run isort --check-only
+    poetry run isort --check-only --diff
 
 [flake8]
 ignore = C901,W503


### PR DESCRIPTION
## Description

- Declares support for Django 3.2. This is tentative only, on the basis of this project having its test suite run with Django master.
- Declares support for Python 3.9, on the basis that the project’s test suite runs with it. Apart from this I’ve done a `runserver` and that’s it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added an appropriate CHANGELOG entry

I will update the CHANGELOG separately.