### PR TITLE
Fix tox issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Update tox config to account for Django's primary branch rename.
+
+
 ## [0.3.0] - 2020-11-02
 
 We have a new documentation website! Check out [torchbox.github.io/django-pattern-library](https://torchbox.github.io/django-pattern-library/).

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-dj{22,30,31,master}, lint
+envlist = py{36,37,38,39}-dj{22,30,31,main}, lint
 skipsdist = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
-    djmaster: https://github.com/django/django/archive/master.zip
+    djmain: https://github.com/django/django/archive/main.zip
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
Django has changed the name of its primary branch to `main`. This fixes the tox config so that tests against the latest version will work again.