### PR TITLE
Add tests and support for Django 3.2, and tentative tests and support for Django 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           poetry-version: '1.1.4'
       - run: pip install tox
-      - run: tox -e lint,py39-dj31
+      - run: tox -e lint,py39-dj32
   test_compatibility:
     needs: test
     runs-on: ubuntu-latest
@@ -28,9 +28,9 @@ jobs:
           - python: "3.7"
             toxenv: py37-dj22,py37-dj30,py37-dj31,py37-dj32
           - python: "3.8"
-            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32
+            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32,py38-djmain
           - python: "3.9"
-            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32
+            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32,py39-djmain
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
       matrix:
         include:
           - python: "3.6"
-            toxenv: py36-dj22,py36-dj30,py36-dj31
+            toxenv: py36-dj22,py36-dj30,py36-dj31,py36-dj32
           - python: "3.7"
-            toxenv: py37-dj22,py37-dj30,py37-dj31
+            toxenv: py37-dj22,py37-dj30,py37-dj31,py37-dj32
           - python: "3.8"
-            toxenv: py38-dj22,py38-dj30,py38-dj31
+            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32
           - python: "3.9"
-            toxenv: py39-dj22,py39-dj30,py39-dj31
+            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- We now officially support Django 3.2
+
 ### Fixed
 
 - Update tox config to account for Django's primary branch rename.
-
 
 ## [0.3.0] - 2020-11-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- We now officially support Django 3.2
+- We now officially support Django 3.2, and tentatively Django 4.0
 
 ### Fixed
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ poetry add --dev django-pattern-library
 
 We support:
 
-- Django 2.2.x, 3.0.x, 3.1.x, 3.2.x (experimental)
+- Django 2.2.x, 3.0.x, 3.1.x, 3.2.x, 4.0.x (experimental)
 - Python 3.6, 3.7, 3.8, 3.9
 - Django Templates only, no Jinja support
 

--- a/pattern_library/urls.py
+++ b/pattern_library/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from pattern_library import get_pattern_template_suffix, views
 
 app_name = 'pattern_library'
 urlpatterns = [
     # UI
-    url(r'^$', views.IndexView.as_view(), name='index'),
-    url(
+    re_path(r'^$', views.IndexView.as_view(), name='index'),
+    re_path(
         r'^pattern/(?P<pattern_template_name>[\w./-]+%s)$' % (
             get_pattern_template_suffix()
         ),
@@ -15,7 +15,7 @@ urlpatterns = [
     ),
 
     # iframe rendering
-    url(
+    re_path(
         r'^render-pattern/(?P<pattern_template_name>[\w./-]+%s)$' % (
             get_pattern_template_suffix()
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
+    "Framework :: Django :: 3.2",
 ]
 packages = [
     { include = "pattern_library" },

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,13 +1,13 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from pattern_library import urls as pattern_library_urls
 
 if settings.GITHUB_PAGES_EXPORT:
     urlpatterns = [
-        url(r'^django-pattern-library/demo/pattern-library/', include(pattern_library_urls)),
+        path('django-pattern-library/demo/pattern-library/', include(pattern_library_urls)),
     ]
 else:
     urlpatterns = [
-        url(r'^pattern-library/', include(pattern_library_urls)),
+        path('pattern-library/', include(pattern_library_urls)),
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-dj{22,30,31,main}, lint
+envlist = py{36,37,38,39}-dj{22,30,31,32,main}, lint
 skipsdist = true
 
 [testenv]
@@ -14,6 +14,7 @@ deps =
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
+    dj32: Django>=3.2,<3.3
     djmain: https://github.com/django/django/archive/main.zip
 
 [testenv:lint]


### PR DESCRIPTION
## Description

This updates our testing matrix to test in Django 3.2 across all Python versions, and in Django 4.0 across Python versions that are supported.

Django 4.0 removes the long-deprecated `django.conf.urls`, so I’ve also updated the urlpatterns to use the `path` and `re_path` replacements.

I chose not to have the Django 4.0 CI builds as experimental / allowed to fail, as it would require splitting the build into even more separate jobs which I’m not a fan of.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
