### PR TITLE
Load templates from template engines’ DIRS setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - We now officially support Django 3.2, and tentatively Django 4.0
+- Load templates from template engines’ [`DIRS`](https://docs.djangoproject.com/en/3.2/ref/settings/#dirs) as well as apps’ `templates` subdirectories.
 
 ### Fixed
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -59,7 +59,7 @@ PATTERN_LIBRARY = {
 ### `SECTIONS`
 
 `SECTIONS` controls the groups of templates that appear in the navigation.
-The keys are the group titles and the values are lists of template name prefixes that will be searched to populate the groups.
+The keys are the group titles and the values are lists of template name prefixes that will be searched to populate the groups. The pattern library searches for templates both in [`DIRS`](https://docs.djangoproject.com/en/3.2/ref/settings/#dirs) directories for template engines, and in the `templates` subdirectory inside each installed application if using [`APP_DIRS`](https://docs.djangoproject.com/en/3.2/ref/settings/#app-dirs).
 
 You can use this to create basic two-folder "includes and pages" hierarchies:
 

--- a/pattern_library/utils.py
+++ b/pattern_library/utils.py
@@ -2,6 +2,7 @@ import operator
 import os
 import re
 
+from django.conf import settings
 from django.template import TemplateDoesNotExist
 from django.template.context import Context
 from django.template.loader import get_template, render_to_string
@@ -66,9 +67,16 @@ def order_dict(dictionary, key_sort=None):
     return dict(values)
 
 
+def get_template_dirs():
+    template_dirs = [d for engines in settings.TEMPLATES for d in engines.get("DIRS", [])]
+    template_app_dirs = get_app_template_dirs('templates')
+    template_dirs += template_app_dirs
+    return template_dirs
+
+
 def get_pattern_templates():
     templates = base_dict()
-    template_dirs = get_app_template_dirs('templates')
+    template_dirs = get_template_dirs()
 
     for lookup_dir in template_dirs:
         for root, dirs, files in os.walk(lookup_dir, topdown=True):

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -1,6 +1,9 @@
-from django.test import SimpleTestCase
+import os
 
-from pattern_library.utils import get_template_ancestors
+from django.conf import settings
+from django.test import SimpleTestCase, override_settings
+
+from pattern_library.utils import get_template_ancestors, get_template_dirs
 
 
 class TestGetTemplateAncestors(SimpleTestCase):
@@ -33,3 +36,40 @@ class TestGetTemplateAncestors(SimpleTestCase):
                 'patterns/base.html',
             ],
         )
+
+    @override_settings(TEMPLATES=[
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+        },
+    ])
+    def test_get_template_dirs_app_dirs(self):
+        template_dirs = ['/'.join(d.replace(os.path.dirname(settings.BASE_DIR), 'dpl').split('/')[-4:-1]) for d in get_template_dirs()]
+        self.assertListEqual(template_dirs, [
+            'django/contrib/auth',
+            'dpl/pattern_library',
+            'dpl/tests',
+        ])
+
+    @override_settings(TEMPLATES=[
+        {
+            'NAME': 'one',
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [os.path.join(settings.BASE_DIR, "test_one", "templates")],
+            'APP_DIRS': True,
+        },
+        {
+            'NAME': 'two',
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [os.path.join(settings.BASE_DIR, "test_two", "templates")],
+        },
+    ])
+    def test_get_template_dirs_list_dirs(self):
+        template_dirs = ['/'.join(d.replace(os.path.dirname(settings.BASE_DIR), 'dpl').split('/')[-4:-1]) for d in get_template_dirs()]
+        self.assertListEqual(template_dirs, [
+            'dpl/tests/test_one',
+            'dpl/tests/test_two',
+            'django/contrib/auth',
+            'dpl/pattern_library',
+            'dpl/tests',
+        ])

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -37,6 +37,14 @@ class TestGetTemplateAncestors(SimpleTestCase):
             ],
         )
 
+
+class TestGetTemplateDirs(SimpleTestCase):
+    def get_relative_template_dirs(self):
+        """Make paths relative with a predefined root so we can use them in assertions."""
+        base = os.path.dirname(settings.BASE_DIR)
+        dirs = get_template_dirs()
+        return ['/'.join(str(d).replace(base, 'dpl').split('/')[-4:-1]) for d in dirs]
+
     @override_settings(TEMPLATES=[
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -44,8 +52,7 @@ class TestGetTemplateAncestors(SimpleTestCase):
         },
     ])
     def test_get_template_dirs_app_dirs(self):
-        template_dirs = ['/'.join(d.replace(os.path.dirname(settings.BASE_DIR), 'dpl').split('/')[-4:-1]) for d in get_template_dirs()]
-        self.assertListEqual(template_dirs, [
+        self.assertListEqual(self.get_relative_template_dirs(), [
             'django/contrib/auth',
             'dpl/pattern_library',
             'dpl/tests',
@@ -65,8 +72,7 @@ class TestGetTemplateAncestors(SimpleTestCase):
         },
     ])
     def test_get_template_dirs_list_dirs(self):
-        template_dirs = ['/'.join(d.replace(os.path.dirname(settings.BASE_DIR), 'dpl').split('/')[-4:-1]) for d in get_template_dirs()]
-        self.assertListEqual(template_dirs, [
+        self.assertListEqual(self.get_relative_template_dirs(), [
             'dpl/tests/test_one',
             'dpl/tests/test_two',
             'django/contrib/auth',


### PR DESCRIPTION
## Description

This makes the pattern library search for templates both in [`DIRS`](https://docs.djangoproject.com/en/3.2/ref/settings/#dirs) directories for template engines, and in the `templates` subdirectory inside each installed application if using [`APP_DIRS`](https://docs.djangoproject.com/en/3.2/ref/settings/#app-dirs) as it was before.

This is necessary so the package is usable for projects that don’t use APP_DIRS.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
