### PR TITLE
Make it better compatibility with Django 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+Define `AppConfig.default_auto_field` as [required since Django 3.2](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys).
+
 ## [0.5.0] - 2021-06-04
 
 ### Added

--- a/pattern_library/apps.py
+++ b/pattern_library/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class PatternLibraryAppConfig(AppConfig):
     name = 'pattern_library'
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
## Description

Include a default auto field in the `apps.py` as accordance to Django 3.2

Related to #153 as it's also about Django 3.2 compatibility but not the exact same issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
