### PR TITLE
Make default_app_config conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Avoid Deprectaion Warnings for Django versions >= 3.2 [Changed in Django 3.2](https://docs.djangoproject.com/en/3.2/ref/applications/#for-application-authors)
+
 - Define `AppConfig.default_auto_field` as [required since Django 3.2](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys).
 - Upgrade PyYAML to v6.0
 

--- a/pattern_library/__init__.py
+++ b/pattern_library/__init__.py
@@ -1,6 +1,9 @@
+import django
+
 from .context_modifiers import register_context_modifier
 
-default_app_config = 'pattern_library.apps.PatternLibraryAppConfig'
+if django.VERSION < (3, 2):
+    default_app_config = "pattern_library.apps.PatternLibraryAppConfig"
 
 __all__ = [
     'DEFAULT_SETTINGS',


### PR DESCRIPTION
## Description

This adds a conditional around default_app_config in __init__.py

The result is when using Django >= 3.2 there are no longer deprecation warnings shown in the console. The warnings can be enabled with `python -Wa manage.py check`

Fixes [# (159)](https://github.com/torchbox/django-pattern-library/issues/159)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
