### PR TITLE
Remove Python 3.6 support; add Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      - uses: Gr1n/setup-poetry@v7
-        with:
-          # Using pre-release to work around Python 3.10 compatibility issue.
-          # See https://github.com/python-poetry/poetry/issues/4210.
-          poetry-version: '1.2.0a2'
+      # Using un-pinned installer to work around Python 3.10 compatibility issue.
+      # See https://github.com/python-poetry/poetry/issues/4210.
+      - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0a2
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,17 @@ jobs:
     strategy:
       matrix:
         include:
+          # Test with all supported Django versions, for all compatible Python versions.
+          # See https://docs.djangoproject.com/en/4.0/faq/install/#what-python-version-can-i-use-with-django for the official matrix.
+          # Additionally test on Django’s main branch with the most recent Python version.
           - python: "3.7"
             toxenv: py37-dj22,py37-dj30,py37-dj31,py37-dj32
           - python: "3.8"
             toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32
           - python: "3.9"
-            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32,py39-djmain
+            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32
           - python: "3.10"
-            toxenv: py310-dj22,py310-dj30,py310-dj31,py310-dj32,py310-djmain
+            toxenv: py310-dj32,py310-djmain
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           poetry-version: '1.1.10'
       - run: pip install tox
-      - run: tox -e lint,py39-dj32
+      - run: tox -e lint,py310-dj32
   test_compatibility:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           poetry-version: '1.1.12'
       - run: pip install tox
-      - run: tox -e lint,py310-dj32
+      - run: tox -e lint,py310-dj40
   test_compatibility:
     needs: test
     runs-on: ubuntu-latest
@@ -29,10 +29,11 @@ jobs:
           - python: "3.7"
             toxenv: py37-dj22,py37-dj30,py37-dj31,py37-dj32
           - python: "3.8"
-            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32
+            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32,py38-dj40
           - python: "3.9"
-            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32
+            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32,py39-dj40
           - python: "3.10"
+            # Skip testing Django 4.0, already tested in previous workflow job.
             toxenv: py310-dj32,py310-djmain
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: "3.6"
-            toxenv: py36-dj22,py36-dj30,py36-dj31,py36-dj32
           - python: "3.7"
             toxenv: py37-dj22,py37-dj30,py37-dj31,py37-dj32
           - python: "3.8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      - uses: Gr1n/setup-poetry@v4
+      - uses: Gr1n/setup-poetry@v7
         with:
-          poetry-version: '1.1.4'
+          poetry-version: '1.1.10'
       - run: pip install tox
       - run: tox -e lint,py39-dj32
   test_compatibility:
@@ -36,9 +36,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - uses: Gr1n/setup-poetry@v4
+      - uses: Gr1n/setup-poetry@v7
         with:
-          poetry-version: '1.1.4'
+          poetry-version: '1.1.10'
       - run: pip install tox
       - run: tox -q
         env:
@@ -62,9 +62,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      - uses: Gr1n/setup-poetry@v4
+      - uses: Gr1n/setup-poetry@v7
         with:
-          poetry-version: '1.1.4'
+          poetry-version: '1.1.10'
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,11 @@ jobs:
           key: ${{ runner.os }}-python-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-python-
-      - run: |
-          poetry config virtualenvs.create false &&
-          poetry install
+      # Disabling experimental installer for compatibility with Python 3.10.
+      # See https://github.com/python-poetry/poetry/issues/4210.
+      - run: poetry config experimental.new-installer false
+      - run: poetry config virtualenvs.create false
+      - run: poetry install
       - run: poetry run django-admin runserver --settings=tests.settings.production --pythonpath=. &
       # Docs website build.
       - run: poetry run mkdocs build --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - uses: Gr1n/setup-poetry@v4
         with:
           poetry-version: '1.1.4'
@@ -26,9 +26,11 @@ jobs:
           - python: "3.7"
             toxenv: py37-dj22,py37-dj30,py37-dj31,py37-dj32
           - python: "3.8"
-            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32,py38-djmain
+            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32
           - python: "3.9"
             toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32,py39-djmain
+          - python: "3.10"
+            toxenv: py310-dj22,py310-dj30,py310-dj31,py310-dj32,py310-djmain
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -59,7 +61,7 @@ jobs:
       - run: npm run build
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - uses: Gr1n/setup-poetry@v4
         with:
           poetry-version: '1.1.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-python-${{ hashFiles('**/pyproject.toml') }}
+          key: ${{ runner.os }}-python-py310-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-python-
+            ${{ runner.os }}-python-py310-
       # Disabling experimental installer for compatibility with Python 3.10.
       # See https://github.com/python-poetry/poetry/issues/4210.
       - run: poetry config experimental.new-installer false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: "3.10"
       - uses: Gr1n/setup-poetry@v7
         with:
-          poetry-version: '1.1.10'
+          poetry-version: '1.1.12'
       - run: pip install tox
       - run: tox -e lint,py310-dj32
   test_compatibility:
@@ -41,7 +41,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - uses: Gr1n/setup-poetry@v7
         with:
-          poetry-version: '1.1.10'
+          poetry-version: '1.1.12'
       - run: pip install tox
       - run: tox -q
         env:
@@ -65,9 +65,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      # Using un-pinned installer to work around Python 3.10 compatibility issue.
-      # See https://github.com/python-poetry/poetry/issues/4210.
-      - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0a2
+      - uses: Gr1n/setup-poetry@v7
+        with:
+          poetry-version: '1.1.12'
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,15 @@ jobs:
           python-version: "3.10"
       - uses: Gr1n/setup-poetry@v7
         with:
-          poetry-version: '1.1.10'
+          # Using pre-release to work around Python 3.10 compatibility issue.
+          # See https://github.com/python-poetry/poetry/issues/4210.
+          poetry-version: '1.2.0a2'
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-python-py310-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-python-py310-
-      # Disabling experimental installer for compatibility with Python 3.10.
-      # See https://github.com/python-poetry/poetry/issues/4210.
-      - run: poetry config experimental.new-installer false
       - run: poetry config virtualenvs.create false
       - run: poetry install
       - run: poetry run django-admin runserver --settings=tests.settings.production --pythonpath=. &

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ poetry add --dev django-pattern-library
 We support:
 
 - Django 2.2.x, 3.0.x, 3.1.x, 3.2.x, 4.0.x (experimental)
-- Python 3.6, 3.7, 3.8, 3.9
+- Python 3.7, 3.8, 3.9
 - Django Templates only, no Jinja support
 
 ## Configuration

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ poetry add --dev django-pattern-library
 We support:
 
 - Django 2.2.x, 3.0.x, 3.1.x, 3.2.x, 4.0.x (experimental)
-- Python 3.7, 3.8, 3.9
+- Python 3.7, 3.8, 3.9, 3.10
 - Django Templates only, no Jinja support
 
 ## Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,5 +61,5 @@ default_section = "THIRDPARTY"
 multi_line_output = 5
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=1.1.10"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,5 +61,5 @@ default_section = "THIRDPARTY"
 multi_line_output = 5
 
 [build-system]
-requires = ["poetry>=1.1.10"]
+requires = ["poetry>=1.1.12"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Framework :: Django",
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -37,7 +36,7 @@ exclude = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 Django = ">=2.2,<4.0"
 PyYAML = ">=5.1,<7.0"
 Markdown = "^3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
 ]
 packages = [
     { include = "pattern_library" },
@@ -38,7 +39,7 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-Django = ">=2.2,<4.0"
+Django = ">=2.2,<4.1"
 PyYAML = ">=5.1,<7.0"
 Markdown = "^3.1"
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,9 +19,6 @@ deps =
 
 [testenv:lint]
 commands =
-    # For compatibility with Python 3.10.
-    # See https://github.com/python-poetry/poetry/issues/4210.
-    poetry config experimental.new-installer false
     poetry install -q
     poetry run flake8
     poetry run isort --check-only --diff

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-dj{22,30,31,32,main}, lint
+envlist = py{37,38,39}-dj{22,30,31,32,main}, lint
 skipsdist = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39}-dj{22,30,31,32,main}, lint
+envlist = py{37,38,39,310}-dj{22,30,31,32,main}, lint
 skipsdist = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310}-dj{22,30,31,32,main}, lint
+envlist = py{37,38,39,310}-dj{22,30,31,32,40,main}, lint
 skipsdist = true
 
 [testenv]
@@ -15,6 +15,7 @@ deps =
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.zip
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,9 @@ deps =
 
 [testenv:lint]
 commands =
+    # For compatibility with Python 3.10.
+    # See https://github.com/python-poetry/poetry/issues/4210.
+    poetry config experimental.new-installer false
     poetry install -q
     poetry run flake8
     poetry run isort --check-only --diff

--- a/tox_install.sh
+++ b/tox_install.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# For compatibility with Python 3.10.
+# See https://github.com/python-poetry/poetry/issues/4210.
+poetry config experimental.new-installer false
 poetry install
 
 if [ ! -z "$@" ]

--- a/tox_install.sh
+++ b/tox_install.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-# For compatibility with Python 3.10.
-# See https://github.com/python-poetry/poetry/issues/4210.
-poetry config experimental.new-installer false
 poetry install
 
 if [ ! -z "$@" ]


### PR DESCRIPTION
## Description

This updates our test suite and the project’s metadata. Python 3.6’s support ends in 3 days. Python 3.10 has been out for a few months now and we need this package to support it. 

The main difficulty here was getting Poetry to cooperate – they had a lot of Python 3.10 compatibility issues, and the `JSONDecodeError` fix from the latest [v1.1.12](https://github.com/python-poetry/poetry/releases/tag/1.1.12) was required.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry

---

Suggested CHANGELOG entry:

```md
### Added

- This package now supports Python 3.10 ([#163](https://github.com/torchbox/django-pattern-library/pull/163).

### Removed

- We no longer support Python 3.6, as it has reached its end of life ([#163](https://github.com/torchbox/django-pattern-library/pull/163).
```
