### PR TITLE
Add support for Django 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           poetry-version: '1.1.12'
       - run: pip install tox
-      - run: tox -e lint,py310-dj32
+      - run: tox -e lint,py310-dj40
   test_compatibility:
     needs: test
     runs-on: ubuntu-latest
@@ -29,10 +29,11 @@ jobs:
           - python: "3.7"
             toxenv: py37-dj22,py37-dj30,py37-dj31,py37-dj32
           - python: "3.8"
-            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32
+            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32,py38-dj40
           - python: "3.9"
-            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32
+            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32,py39-dj40
           - python: "3.10"
+            # Skip testing Django 4.0, already tested in previous workflow job.
             toxenv: py310-dj32,py310-djmain
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
 ]
 packages = [
     { include = "pattern_library" },
@@ -38,7 +39,7 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-Django = ">=2.2,<4.0"
+Django = ">=2.2,<4.1"
 PyYAML = ">=5.1,<7.0"
 Markdown = "^3.1"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310}-dj{22,30,31,32,main}, lint
+envlist = py{37,38,39,310}-dj{22,30,31,32,40,main}, lint
 skipsdist = true
 
 [testenv]
@@ -15,6 +15,7 @@ deps =
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.zip
 
 [testenv:lint]


### PR DESCRIPTION
## Description

**Depends on #163**. Updates the project’s test suite and metadata to support Django 4.0. I’ve done some brief testing of the pattern library with this version and couldn’t spot anything off (aside from #166, but I believe that can be done separately).

We could also remove our testing for Django 3.0 and 3.1 at the same time since they’re not technically supported anymore.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry

---

Suggested CHANGELOG entry:

```md
## Added

- Support Django 4.0 ([#164](https://github.com/torchbox/django-pattern-library/pull/164)).
```
