### PR TITLE
Change values in .yaml for tests in Django 4.0

### DIFF
--- a/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
+++ b/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
@@ -3,9 +3,9 @@ tags:
     empty_string:
       raw: ''
     none:
-      raw: null
+      raw: 'None'
     zero:
-      raw: 0
+      raw: '0'
   default_html_tag:
     page.url:
       raw: "example"
@@ -16,7 +16,7 @@ tags:
     empty_string:
       raw: ''
     none:
-      raw: null
+      raw: 'None'
     zero:
-      raw: 0
+      raw: '0'
   


### PR DESCRIPTION
## Description

Tests failed when running against Django 4.0

The .yaml file values needed to be changed to 'strings' but I'm not entirely sure why that works here.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added an appropriate CHANGELOG entry
