### PR TITLE
Add API endpoint for pattern rendering via POST

### DIFF
--- a/docs/recipes/api-rendering.md
+++ b/docs/recipes/api-rendering.md
@@ -1,0 +1,25 @@
+# API rendering
+
+For additional flexibility, django-pattern-library supports rendering patterns via an API endpoint.
+This can be useful when implementing a custom UI while still using the pattern library’s Django rendering features.
+
+The API endpoint is available at `api/v1/render-pattern`. It accepts POST requests with a JSON payload containing the following fields:
+
+- `template_name` – the path of the template to render
+- `config` – the configuration for the template, with the same data structure as the configuration files (`context` and `tags`).
+
+Here is an example, with curl:
+
+```bash
+echo '{"template_name": "patterns/molecules/button/button.html", "config": {"context": {"target_page": {"title": "API"}}, "tags": {"pageurl":{"target_page":{"raw": "/hello-api"}}}}}' | curl -d @- http://localhost:8000/api/v1/render-pattern
+```
+
+The response will be the pattern’s rendered HTML:
+
+```html
+<a href="/hello-api" class="button">
+    API
+</a>
+```
+
+Note compared to iframe rendering, this API always renders the pattern’s HTML standalone, never within a base template.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
     - 'Inclusion tags': 'recipes/inclusion-tags.md'
     - 'Looping for tags': 'recipes/looping-for-tags.md'
     - 'Pagination': 'recipes/pagination.md'
+    - 'API rendering': 'recipes/api-rendering.md'
   - 'Reference':
     - 'API and settings': 'reference/api.md'
     - 'Concepts': 'reference/concepts.md'

--- a/pattern_library/monkey_utils.py
+++ b/pattern_library/monkey_utils.py
@@ -3,7 +3,6 @@ import logging
 from django.template.library import SimpleNode
 
 from pattern_library.utils import (
-    get_pattern_config,
     is_pattern_library_context,
     render_pattern,
 )
@@ -33,7 +32,7 @@ def override_tag(register, name, default_html=None):
 
                 # Load pattern's config
                 current_template_name = parser.origin.template_name
-                pattern_config = get_pattern_config(current_template_name)
+                tag_overrides = context.get("__pattern_library_tag_overrides", {})
 
                 # Extract values for lookup from the token
                 bits = token.split_contents()
@@ -41,7 +40,7 @@ def override_tag(register, name, default_html=None):
                 arguments = " ".join(bits[1:]).strip()
 
                 # Get config for a specific tag
-                tag_config = pattern_config.get("tags", {}).get(tag_name, {})
+                tag_config = tag_overrides.get(tag_name, {})
                 if tag_config:
                     # Get config for specific arguments
                     tag_config = tag_config.get(arguments, {})

--- a/pattern_library/monkey_utils.py
+++ b/pattern_library/monkey_utils.py
@@ -30,8 +30,7 @@ def override_tag(register, name, default_html=None):
                 tag_overridden = False
                 result = ""
 
-                # Load pattern's config
-                current_template_name = parser.origin.template_name
+                # Get overriden tag config.
                 tag_overrides = context.get("__pattern_library_tag_overrides", {})
 
                 # Extract values for lookup from the token
@@ -87,7 +86,7 @@ def override_tag(register, name, default_html=None):
                     logger.warning(
                         'No default or stub data defined for the "%s" tag in the "%s" template',
                         tag_name,
-                        current_template_name,
+                        parser.origin.template_name,
                     )
 
             return original_node_render(context)

--- a/pattern_library/monkey_utils.py
+++ b/pattern_library/monkey_utils.py
@@ -2,10 +2,7 @@ import logging
 
 from django.template.library import SimpleNode
 
-from pattern_library.utils import (
-    is_pattern_library_context,
-    render_pattern,
-)
+from pattern_library.utils import is_pattern_library_context, render_pattern
 
 logger = logging.getLogger(__name__)
 UNSPECIFIED = object()

--- a/pattern_library/urls.py
+++ b/pattern_library/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, path
+from django.urls import path, re_path
 
 from pattern_library import get_pattern_template_suffix, views
 
@@ -19,7 +19,6 @@ urlpatterns = [
         views.RenderPatternView.as_view(),
         name="render_pattern",
     ),
-
     # API rendering
-    path('api/v1/render-pattern', views.render_pattern_api, name='render_pattern_api'),
+    path("api/v1/render-pattern", views.render_pattern_api, name="render_pattern_api"),
 ]

--- a/pattern_library/urls.py
+++ b/pattern_library/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import re_path, path
 
 from pattern_library import get_pattern_template_suffix, views
 
@@ -19,4 +19,7 @@ urlpatterns = [
         views.RenderPatternView.as_view(),
         name="render_pattern",
     ),
+
+    # API rendering
+    path('api/v1/render-pattern', views.render_pattern_api, name='render_pattern_api'),
 ]

--- a/pattern_library/utils.py
+++ b/pattern_library/utils.py
@@ -217,11 +217,11 @@ def render_pattern(request, template_name, allow_non_patterns=False, config=None
     if not config:
         config = get_pattern_config(template_name)
 
-    context = config.get('context', {})
-    tags = config.get('tags', {})
+    context = config.get("context", {})
+    tags = config.get("tags", {})
     mark_context_strings_safe(context)
     context[get_pattern_context_var_name()] = True
-    context['__pattern_library_tag_overrides'] = tags
+    context["__pattern_library_tag_overrides"] = tags
     for modifier in registry.get_for_template(template_name):
         modifier(context=context, request=request)
     return render_to_string(template_name, request=request, context=context)

--- a/pattern_library/utils.py
+++ b/pattern_library/utils.py
@@ -210,12 +210,18 @@ def get_pattern_markdown(template_name):
         return markdown.markdown(f.read())
 
 
-def render_pattern(request, template_name, allow_non_patterns=False):
+def render_pattern(request, template_name, allow_non_patterns=False, config=None):
     if not allow_non_patterns and not is_pattern(template_name):
         raise TemplateIsNotPattern
 
-    context = get_pattern_context(template_name)
+    if not config:
+        config = get_pattern_config(template_name)
+
+    context = config.get('context', {})
+    tags = config.get('tags', {})
+    mark_context_strings_safe(context)
     context[get_pattern_context_var_name()] = True
+    context['__pattern_library_tag_overrides'] = tags
     for modifier in registry.get_for_template(template_name):
         modifier(context=context, request=request)
     return render_to_string(template_name, request=request, context=context)

--- a/pattern_library/views.py
+++ b/pattern_library/views.py
@@ -6,7 +6,7 @@ from django.utils.decorators import method_decorator
 from django.utils.html import escape
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic.base import TemplateView, View
+from django.views.generic.base import TemplateView
 
 from pattern_library import get_base_template_names, get_pattern_base_template_name
 from pattern_library.exceptions import PatternLibraryEmpty, TemplateIsNotPattern
@@ -111,7 +111,9 @@ def render_pattern_api(request):
     config = data["config"]
 
     try:
-        rendered_pattern = render_pattern(request, template_name, allow_non_patterns=False, config=config)
+        rendered_pattern = render_pattern(
+            request, template_name, allow_non_patterns=False, config=config
+        )
     except TemplateIsNotPattern:
         raise Http404
 

--- a/tests/templates/patterns/molecules/button/button.html
+++ b/tests/templates/patterns/molecules/button/button.html
@@ -1,0 +1,4 @@
+{% load test_tags %}
+<a href="{% if target_url %}{{ target_url }}{% else %}{% pageurl target_page %}{% endif %}" class="button">
+    {% if label %}{{ label }}{% else %}{{ target_page.title }}{% endif %}
+</a>

--- a/tests/templates/patterns/molecules/button/button.yaml
+++ b/tests/templates/patterns/molecules/button/button.yaml
@@ -1,0 +1,7 @@
+context:
+  target_page:
+    title: Get started
+tags:
+  pageurl:
+    target_page:
+      raw: /get-started

--- a/tests/templatetags/test_tags.py
+++ b/tests/templatetags/test_tags.py
@@ -27,6 +27,12 @@ def default_html_tag_falsey(arg=None):
     raise Exception("default_tag raised an exception")
 
 
+@register.simple_tag()
+def pageurl(page):
+    """Approximation of wagtail built-in tag for realistic example."""
+    return "/page/url"
+
+
 # Get widget type of a field
 @register.filter(name="widget_type")
 def widget_type(bound_field):
@@ -36,3 +42,4 @@ def widget_type(bound_field):
 override_tag(register, "error_tag")
 override_tag(register, "default_html_tag", default_html="https://potato.com")
 override_tag(register, "default_html_tag_falsey", default_html=None)
+override_tag(register, "pageurl")

--- a/tests/tests/test_context_modifiers.py
+++ b/tests/tests/test_context_modifiers.py
@@ -125,6 +125,7 @@ class ContextModifierTestCase(SimpleTestCase):
             context={
                 "atom_var": "atom_var value from test_atom.yaml",
                 "is_pattern_library": True,
+                "__pattern_library_tag_overrides": {},
                 "foo": "bar",
                 "beep": "boop",
             },

--- a/tests/tests/test_views.py
+++ b/tests/tests/test_views.py
@@ -132,7 +132,7 @@ class APIViewsTestCase(SimpleTestCase):
                 },
             },
         )
-        self.assertContains(response, '/hello-api')
+        self.assertContains(response, "/hello-api")
 
     def test_404(self):
         api_endpoint = reverse("pattern_library:render_pattern_api")

--- a/tests/tests/test_views.py
+++ b/tests/tests/test_views.py
@@ -116,3 +116,32 @@ class ViewsTestCase(SimpleTestCase):
             ),
             "base content - extended content",
         )
+
+
+class APIViewsTestCase(SimpleTestCase):
+    def test_renders_with_tag_overrides(self):
+        api_endpoint = reverse("pattern_library:render_pattern_api")
+        response = self.client.post(
+            api_endpoint,
+            content_type="application/json",
+            data={
+                "template_name": "patterns/molecules/button/button.html",
+                "config": {
+                    "context": {"target_page": {"title": "API"}},
+                    "tags": {"pageurl": {"target_page": {"raw": "/hello-api"}}},
+                },
+            },
+        )
+        self.assertContains(response, '/hello-api')
+
+    def test_404(self):
+        api_endpoint = reverse("pattern_library:render_pattern_api")
+        response = self.client.post(
+            api_endpoint,
+            content_type="application/json",
+            data={
+                "template_name": "doesnotexist.html",
+                "config": {},
+            },
+        )
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
## Description

Addresses #104. This adds an API endpoint built into the pattern library, and changes how tag overrides are loaded. This is so they can be loaded from the API data, rather than always loading the YAML file.

I could use additional feedback on this before adding the tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry

---

To test this:

```sh
 echo '{"template_name": "patterns/molecules/button/button.html", "config": {"context": {"target_page": {"title": "API"}}, "tags": {"pageurl":{"target_page":{"raw": "/hello-api"}}}}}' | curl -d @- http://localhost:8000/pattern-library/api/v1/render-pattern
```

Suggested CHANGELOG entry:

```markdown
### Added

- New `/api/v1/render-pattern` [API endpoint to render patterns](https://torchbox.github.io/django-pattern-library/recipes/api-rendering/) via POST requests, with the pattern’s context and tag overrides as a JSON body ([#168](https://github.com/torchbox/django-pattern-library/pull/168)).
```