### PR TITLE
Add docs and tentative support mentions for Python 3.11 & Django 4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           - python: "3.10"
             # Skip testing Django 4.0, already tested in previous workflow job.
             toxenv: py310-dj32,py310-djmain
+            # Tentative support for next Python pre-release.
+          - python: "3.11.0-alpha.4"
+            toxenv: py311-dj40
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
           # See https://docs.djangoproject.com/en/4.0/faq/install/#what-python-version-can-i-use-with-django for the official matrix.
           # Additionally test on Django’s main branch with the most recent Python version.
           - python: "3.7"
-            toxenv: py37-dj22,py37-dj30,py37-dj31,py37-dj32
+            toxenv: py37-dj22,py37-dj32
           - python: "3.8"
-            toxenv: py38-dj22,py38-dj30,py38-dj31,py38-dj32,py38-dj40
+            toxenv: py38-dj22,py38-dj32,py38-dj40
           - python: "3.9"
-            toxenv: py39-dj22,py39-dj30,py39-dj31,py39-dj32,py39-dj40
+            toxenv: py39-dj22,py39-dj32,py39-dj40
           - python: "3.10"
             # Skip testing Django 4.0, already tested in previous workflow job.
             toxenv: py310-dj32,py310-djmain

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ poetry add --dev django-pattern-library
 
 We support:
 
-- Django 2.2, 3.0, 3.1, 3.2, 4.0, 4.1 (experimental)
+- Django 2.2, 3.2, 4.0, 4.1 (experimental)
 - Python 3.7, 3.8, 3.9, 3.10, 3.11 (experimental)
 - Django Templates only, no Jinja support
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,8 +17,8 @@ poetry add --dev django-pattern-library
 
 We support:
 
-- Django 2.2.x, 3.0.x, 3.1.x, 3.2.x, 4.0.x (experimental)
-- Python 3.7, 3.8, 3.9, 3.10
+- Django 2.2, 3.0, 3.1, 3.2, 4.0, 4.1 (experimental)
+- Python 3.7, 3.8, 3.9, 3.10, 3.11 (experimental)
 - Django Templates only, no Jinja support
 
 ## Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Framework :: Django",
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Framework :: Django",
     "Framework :: Django :: 2.2",
-    "Framework :: Django :: 3.0",
-    "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ Markdown = "^3.1"
 
 [tool.poetry.dev-dependencies]
 beautifulsoup4 = "^4.8"
-coverage = "^4.5"
+coverage = "^6.2"
 flake8 = "^3.7"
 isort = "^5.10.1"
 mkdocs = "^1.1.2"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}-dj{22,30,31,32,40,main}, lint
+envlist = py{37,38,39,310,311}-dj{22,32,40,main}, lint
 skipsdist = true
 
 [testenv]
@@ -12,8 +12,6 @@ commands =
     poetry run django-admin render_patterns --settings=tests.settings.dev --pythonpath=. --dry-run
 deps =
     dj22: Django>=2.2,<2.3
-    dj30: Django>=3.0,<3.1
-    dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.zip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310}-dj{22,30,31,32,40,main}, lint
+envlist = py{37,38,39,310,311}-dj{22,30,31,32,40,main}, lint
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
## Description

We’re already testing against Django’s `main` (currently 4.1 dev). This adds tests for Python 3.11 (alpha release), and updates our support targets to match.

I’ve also removed tests & support mentions for Django 3.0 and 3.1, to reflect the fact they’re now end-of-life.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry

Proposed CHANGELOG entries:

```
## Added

- Tentatively add support for Python 3.11
- Tentatively add support for Django 4.1

## Removed

- Remove support for Django 3.0.
- Remove support for Django 3.1
```
