### PR TITLE
Fix #166, making sure we always cast raw tag override values to string

### DIFF
--- a/pattern_library/monkey_utils.py
+++ b/pattern_library/monkey_utils.py
@@ -78,8 +78,9 @@ def override_tag(register, name, default_html=None):
                         context[target_var] = result
                         return ""
 
-                    # Render result instead of the tag
-                    return result
+                    # Render result instead of the tag, as a string.
+                    # See https://github.com/torchbox/django-pattern-library/issues/166.
+                    return str(result)
                 elif default_html is not UNSPECIFIED:
                     # Render provided default;
                     # if no stub data supplied.

--- a/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
+++ b/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.yaml
@@ -3,9 +3,9 @@ tags:
     empty_string:
       raw: ''
     none:
-      raw: 'None'
+      raw: None
     zero:
-      raw: '0'
+      raw: 0
   default_html_tag:
     page.url:
       raw: "example"
@@ -16,7 +16,6 @@ tags:
     empty_string:
       raw: ''
     none:
-      raw: 'None'
+      raw: None
     zero:
-      raw: '0'
-  
+      raw: 0


### PR DESCRIPTION
## Description

Fixes #166, following the suggestion from @zerolab. I chose to do this for all Django versions rather than adding a conditional with version check, but happy to revisit this if people think it’s worthwhile.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~ Not relevant
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry

Suggested CHANGELOG entry:

```markdown
### Changed

- Fix potential Django 4.0 compatibility issue for components using non-string values in tag overrides ([#166](https://github.com/torchbox/django-pattern-library/issues/166)).
```
