### PR TITLE
Add type annotations to public API. Fix #172

### DIFF
--- a/pattern_library/monkey_utils.py
+++ b/pattern_library/monkey_utils.py
@@ -1,5 +1,7 @@
 import logging
+from typing import Optional
 
+import django
 from django.template.library import SimpleNode
 
 from pattern_library.utils import (
@@ -12,11 +14,11 @@ logger = logging.getLogger(__name__)
 UNSPECIFIED = object()
 
 
-def override_tag(register, name, default_html=None):
+def override_tag(
+    register: django.template.Library, name: str, default_html: Optional[str] = None
+):
     """
     An utility that helps you override original tags for use in your pattern library.
-
-    Accepts the register argument which should be an instance of django.template.Library.
     """
 
     original_tag = register.tags[name]


### PR DESCRIPTION
## Description

Fixes #172. The public Python API is only made up of `register_context_modifier`, which is already typed correctly, and `override_tag`, which has a pretty simple signature.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry

Suggested CHANGELOG entry:

```markdown
### Added

- The package is now published with type hints for the public API (`register_context_modifier` and `override_tag`) ([#172](https://github.com/torchbox/django-pattern-library/issues/172), [#189](https://github.com/torchbox/django-pattern-library/pull/189)).