### PR TITLE
Fix tag overrides’ default_html preventing real tag usage

### DIFF
--- a/pattern_library/monkey_utils.py
+++ b/pattern_library/monkey_utils.py
@@ -7,7 +7,6 @@ from django.template.library import SimpleNode
 from pattern_library.utils import is_pattern_library_context, render_pattern
 
 logger = logging.getLogger(__name__)
-UNSPECIFIED = object()
 
 
 def override_tag(
@@ -78,7 +77,7 @@ def override_tag(
                     # Render result instead of the tag, as a string.
                     # See https://github.com/torchbox/django-pattern-library/issues/166.
                     return str(result)
-                elif default_html is not UNSPECIFIED:
+                elif default_html is not None:
                     # Render provided default;
                     # if no stub data supplied.
                     return default_html

--- a/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.html
+++ b/tests/templates/patterns/atoms/tags_test_atom/tags_test_atom.html
@@ -4,10 +4,12 @@ SAND{% error_tag empty_string %}WICH
 SAND{% error_tag none %}WICH
 SAND{% error_tag zero %}WICH
 
-POTA{% default_html_tag page.url %}TO 
+POTA{% default_html_tag page.url %}TO
 POTA{% default_html_tag page.child.url %}TO
 POTA{% default_html_tag None %}TO
 
 POTA{% default_html_tag_falsey empty_string %}TO1
 POTA{% default_html_tag_falsey none %}TO2
 POTA{% default_html_tag_falsey zero %}TO3
+
+Real tag usage: {% pageurl page %}

--- a/tests/tests/test_tags.py
+++ b/tests/tests/test_tags.py
@@ -4,6 +4,17 @@ from .utils import reverse
 
 
 class TagsTestCase(SimpleTestCase):
+    def test_real_tag_usage(self):
+        response = self.client.get(
+            reverse(
+                "pattern_library:render_pattern",
+                kwargs={
+                    "pattern_template_name": "patterns/atoms/tags_test_atom/tags_test_atom.html"
+                },
+            )
+        )
+        self.assertContains(response, "Real tag usage: /page/url")
+
     def test_falsey_raw_values_for_tag_output(self):
         response = self.client.get(
             reverse(


### PR DESCRIPTION
## Description

This fixes a bug with our tag overrides’ support for default values. As implemented currently, we can no longer just let the tag render as normal – the default value would always take precedence, even if unset.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~ Not needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- ~[ ] I have added an appropriate CHANGELOG entry~ Will do this once merged
