### PR TITLE
Disable pointer events on menu chevron to allow toggling. Fix #202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Disable pointer events on chevron [CSS styling change](https://github.com/torchbox/django-pattern-library/pull/205)
+- Disable pointer events on menu chevron to allow clicks ([#202](https://github.com/torchbox/django-pattern-library/issues/202), [#205](https://github.com/torchbox/django-pattern-library/pull/205))
 
 ## [1.0.0](https://github.com/torchbox/django-pattern-library/releases/tag/v1.0.0) - 2022-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Disable pointer events on chevron [CSS styling change](https://github.com/torchbox/django-pattern-library/pull/205)
+
 ## [1.0.0](https://github.com/torchbox/django-pattern-library/releases/tag/v1.0.0) - 2022-06-10
 
 ### Added

--- a/pattern_library/static/pattern_library/src/scss/components/_list.scss
+++ b/pattern_library/static/pattern_library/src/scss/components/_list.scss
@@ -43,7 +43,8 @@
     &__item-icon {
         width: 15px;
         height: 15px;
-
+        pointer-events: none;
+        
         .is-open > & {
             transform: rotate(90deg);
         }


### PR DESCRIPTION
## Description

A small styling change to stop the chevron SVG catching the menu clicks.

Fixes https://github.com/torchbox/django-pattern-library/issues/202

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
