### PR TITLE
Make it possible to navigate the menu with the keyboard. Fix #202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Disable pointer events on menu chevron to allow clicks ([#202](https://github.com/torchbox/django-pattern-library/issues/202), [#205](https://github.com/torchbox/django-pattern-library/pull/205))
+- Improve menu accessibility by using buttons for menu items ([#207](https://github.com/torchbox/django-pattern-library/pull/207)).
 
 ## [1.0.0](https://github.com/torchbox/django-pattern-library/releases/tag/v1.0.0) - 2022-06-10
 

--- a/pattern_library/static/pattern_library/src/js/components/navigation.js
+++ b/pattern_library/static/pattern_library/src/js/components/navigation.js
@@ -1,10 +1,11 @@
 export function toggleNavItems() {
-    const headings = document.querySelectorAll('.js-toggle-pattern');
-    headings.forEach(heading => {
-        heading.addEventListener('click', e => {
+    const categoryButtons = document.querySelectorAll('.js-toggle-pattern');
+
+    categoryButtons.forEach((button) => {
+        button.addEventListener('click', (e) => {
             e.target.classList.toggle('is-open');
-            for ( const element of e.target.parentNode.childNodes ) {
-                if ( element.nodeName === "UL" ){
+            for (const element of e.target.closest('.js-list-item').childNodes) {
+                if (element.nodeName === 'UL') {
                     element.classList.toggle('is-open');
                 }
             }

--- a/pattern_library/static/pattern_library/src/scss/components/_list.scss
+++ b/pattern_library/static/pattern_library/src/scss/components/_list.scss
@@ -45,6 +45,7 @@
         width: 15px;
         height: 15px;
         pointer-events: none;
+        transition: transform 0.15s ease-in-out;
 
         .is-open > & {
             transform: rotate(90deg);

--- a/pattern_library/static/pattern_library/src/scss/components/_list.scss
+++ b/pattern_library/static/pattern_library/src/scss/components/_list.scss
@@ -45,7 +45,7 @@
         width: 15px;
         height: 15px;
         pointer-events: none;
-        
+
         .is-open > & {
             transform: rotate(90deg);
         }

--- a/pattern_library/static/pattern_library/src/scss/components/_list.scss
+++ b/pattern_library/static/pattern_library/src/scss/components/_list.scss
@@ -19,23 +19,24 @@
         padding-left: 15px;
     }
 
-    &__item-heading {
+    &__button {
         display: flex;
         align-items: center;
         margin: 10px 0;
         user-select: none;
-        font-weight: 500;
         font-size: 19px;
+        appearance: none;
+        background-color: transparent;
+        border: 0;
+        gap: 5px;
+        padding: 0;
 
         &:hover {
             cursor: pointer;
         }
 
-        &--light {
-            font-weight: 200;
-        }
-
-        &--small{
+        &--child {
+            color: $mid-grey;
             font-size: 13px;
         }
     }

--- a/pattern_library/static/pattern_library/src/scss/layout/_sidebar.scss
+++ b/pattern_library/static/pattern_library/src/scss/layout/_sidebar.scss
@@ -1,11 +1,14 @@
 .sidebar {
     background-color: $off-white;
-    padding: 20px;
     height: 100vh;
     margin-left: 0;
     overflow: auto;
     -ms-grid-column: 1;
     -ms-grid-row: 2;
+
+    &__inner {
+        padding: 20px;
+    }
 
     &__search {
         width: 100%;

--- a/pattern_library/templates/pattern_library/base.html
+++ b/pattern_library/templates/pattern_library/base.html
@@ -28,18 +28,18 @@
         <nav class="sidebar__nav" id="sidebar-nav">
             <ul class="list">
                 {% for pattern_type_group, pattern_templates in pattern_templates.template_groups.items %}
-                <li class="list__item">
-                    <h2 class="list__item-heading js-toggle-pattern">
-                        <svg class="list__item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
-                            <path d="M88 80l-48 48 16 16 64-64-64-64-16 16 48 48z" />
-                        </svg>
-                        {{ pattern_type_group|title }}
-                    </h2>
-                    {% include "pattern_library/pattern_group.html" with groups=pattern_templates.template_groups %}
-                </li>
                 {% endfor %}
             </ul>
         </nav>
+                    <li class="list__item js-list-item">
+                        <button class="list__button js-toggle-pattern">
+                            <svg class="list__item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+                                <path d="M88 80l-48 48 16 16 64-64-64-64-16 16 48 48z" />
+                            </svg>
+                            {{ pattern_type_group|title }}
+                        </button>
+                        {% include "pattern_library/pattern_group.html" with groups=pattern_templates.template_groups %}
+                    </li>
     </aside>
     <main class="main">
         {% block content %}{% endblock %}

--- a/pattern_library/templates/pattern_library/base.html
+++ b/pattern_library/templates/pattern_library/base.html
@@ -22,15 +22,13 @@
         </h1>
     </header>
     <aside class="sidebar">
-        <label for="js-pattern-search-input" class="is-hidden">Search pattern library</label>
-        <input type="text" class="sidebar__search" id="js-pattern-search-input" placeholder="Search library...">
-        <div class="sidebar__search-results" id="js-pattern-search-results-container"></div>
-        <nav class="sidebar__nav" id="sidebar-nav">
-            <ul class="list">
-                {% for pattern_type_group, pattern_templates in pattern_templates.template_groups.items %}
-                {% endfor %}
-            </ul>
-        </nav>
+        <div class="sidebar__inner">
+            <label for="js-pattern-search-input" class="is-hidden">Search pattern library</label>
+            <input type="text" class="sidebar__search" id="js-pattern-search-input" placeholder="Search library...">
+            <div class="sidebar__search-results" id="js-pattern-search-results-container"></div>
+            <nav class="sidebar__nav" id="sidebar-nav">
+                <ul class="list">
+                    {% for pattern_type_group, pattern_templates in pattern_templates.template_groups.items %}
                     <li class="list__item js-list-item">
                         <button class="list__button js-toggle-pattern">
                             <svg class="list__item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
@@ -40,6 +38,10 @@
                         </button>
                         {% include "pattern_library/pattern_group.html" with groups=pattern_templates.template_groups %}
                     </li>
+                    {% endfor %}
+                </ul>
+            </nav>
+        </div>
     </aside>
     <main class="main">
         {% block content %}{% endblock %}

--- a/pattern_library/templates/pattern_library/base.html
+++ b/pattern_library/templates/pattern_library/base.html
@@ -30,7 +30,7 @@
                 <ul class="list">
                     {% for pattern_type_group, pattern_templates in pattern_templates.template_groups.items %}
                     <li class="list__item js-list-item">
-                        <button class="list__button js-toggle-pattern">
+                        <button class="list__button list__button--parent js-toggle-pattern">
                             <svg class="list__item-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
                                 <path d="M88 80l-48 48 16 16 64-64-64-64-16 16 48 48z" />
                             </svg>

--- a/pattern_library/templates/pattern_library/pattern_group.html
+++ b/pattern_library/templates/pattern_library/pattern_group.html
@@ -1,12 +1,12 @@
 <ul class="list list--child">
     {% for group_name, pattern_templates in groups.items %}
-    <li class="list__item">
-        <h3 class="list__item-heading list__item-heading--small list__item-heading--light js-toggle-pattern">
+    <li class="list__item js-list-item">
+        <button class="list__button list__button--child js-toggle-pattern">
             <svg class="list__item-icon list__item-icon--small" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
                 <path d="M88 80l-48 48 16 16 64-64-64-64-16 16 48 48z" />
             </svg>
             {{ group_name }}
-        </h3>
+        </button>
         {% if pattern_templates.template_groups %}
             {% include "pattern_library/pattern_group.html" with groups=pattern_templates.template_groups %}
         {% endif %}

--- a/pattern_library/templates/pattern_library/pattern_group.html
+++ b/pattern_library/templates/pattern_library/pattern_group.html
@@ -3,7 +3,7 @@
     <li class="list__item js-list-item">
         <button class="list__button list__button--child js-toggle-pattern">
             <svg class="list__item-icon list__item-icon--small" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
-                <path d="M88 80l-48 48 16 16 64-64-64-64-16 16 48 48z" />
+                <path d="M88 80l-48 48 16 16 64-64-64-64-16 16 48 48z" fill="currentColor" />
             </svg>
             {{ group_name }}
         </button>

--- a/tests/tests/test_sections.py
+++ b/tests/tests/test_sections.py
@@ -13,7 +13,7 @@ class SectionsTestCase(SimpleTestCase):
 
         soup = BeautifulSoup(response.content, features="html.parser")
         sidebar_nav = soup.select_one("#sidebar-nav")
-        sections = [h.text.strip() for h in sidebar_nav.find_all("button")]
+        sections = [h.text.strip() for h in sidebar_nav.find_all("button", {"class": "list__button--parent"})]
 
         return sections
 

--- a/tests/tests/test_sections.py
+++ b/tests/tests/test_sections.py
@@ -13,7 +13,7 @@ class SectionsTestCase(SimpleTestCase):
 
         soup = BeautifulSoup(response.content, features="html.parser")
         sidebar_nav = soup.select_one("#sidebar-nav")
-        sections = [h.text.strip() for h in sidebar_nav.find_all("h2")]
+        sections = [h.text.strip() for h in sidebar_nav.find_all("button")]
 
         return sections
 

--- a/tests/tests/test_sections.py
+++ b/tests/tests/test_sections.py
@@ -13,7 +13,10 @@ class SectionsTestCase(SimpleTestCase):
 
         soup = BeautifulSoup(response.content, features="html.parser")
         sidebar_nav = soup.select_one("#sidebar-nav")
-        sections = [h.text.strip() for h in sidebar_nav.find_all("button", {"class": "list__button--parent"})]
+        sections = [
+            h.text.strip()
+            for h in sidebar_nav.find_all("button", {"class": "list__button--parent"})
+        ]
 
         return sections
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py{37,38,39,310,311}-dj{32,40,41,main}, lint
 skipsdist = true
 
 [testenv]
-whitelist_externals =
+allowlist_externals =
     poetry
 install_command =
     ./tox_install.sh {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 allowlist_externals =
     poetry
+    ./tox_install.sh
 install_command =
     ./tox_install.sh {packages}
 commands =


### PR DESCRIPTION
## Description

Currently the pattern library uses the menu item heading tags to listen for events which open and close their child menus. This is not accessible for users who navigate via keyboard only.  

This MR resolves that by changing the menu item elements to buttons. In turn it also resolves https://github.com/torchbox/django-pattern-library/issues/202.

It also:
- Moves the padding on `.sidebar` to a new element `.sidebar__inner` as when the sidebar is collapsed the padding meant the elements within the sidebar were still visible.
- Updates a Tox config option: `whitelist_externals` is replaced by `allowlist_externals` - https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4

Fixes #202

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
