### PR TITLE
feat: Support Django 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
           - python: "3.7"
             toxenv: py37-dj32
           - python: "3.8"
-            toxenv: py38-dj32,py38-dj40,py38-dj41
+            toxenv: py38-dj32,py38-dj40,py38-dj41,py38-dj42
           - python: "3.9"
-            toxenv: py39-dj32,py39-dj40,py39-dj41
+            toxenv: py39-dj32,py39-dj40,py39-dj41,py38-dj42
           - python: "3.10"
             # Skip testing Django 4.0, already tested in previous workflow job.
-            toxenv: py310-dj32,py310-dj41,py310-djmain
+            toxenv: py310-dj32,py310-dj41,py310-dj42py,py310-djmain
           - python: "3.11"
             toxenv: py311-dj41,py311-dj42,py311-djmain
             # Tentative support for next Python pre-release. For the correct specifier,
@@ -50,8 +50,12 @@ jobs:
       - uses: Gr1n/setup-poetry@v7
         with:
           poetry-version: '1.1.12'
-      - run: pip install tox
-      - run: tox -q
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+      - name: Tox Test
+        run: tox
         env:
           TOXENV: ${{ matrix.toxenv }}
   build_site:
@@ -83,7 +87,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-python-py310-
       - run: poetry config virtualenvs.create false
-      - run: poetry install
+      - run: poetry install --extras 'test'
       - run: poetry run django-admin runserver --settings=tests.settings.production --pythonpath=. &
       # Docs website build.
       - run: poetry run mkdocs build --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,13 @@ jobs:
           - python: "3.10"
             # Skip testing Django 4.0, already tested in previous workflow job.
             toxenv: py310-dj32,py310-dj41,py310-djmain
+          - python: "3.11"
+            toxenv: py311-dj41,py311-dj42,py311-djmain
             # Tentative support for next Python pre-release. For the correct specifier,
             # Check: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json.
-          - python: "3.11.0-beta.2"
-            toxenv: py311-dj41
+            # when django supports py312, then uncomment this
+            # - python: "3.12.0-alpha.6"
+            #   toxenv: py312-dj41
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-
+- Tentative support for Django 4.2 ([#212](https://github.com/torchbox/django-pattern-library/issues/212),[#213](https://github.com/torchbox/django-pattern-library/pull/213)).
 - Disable pointer events on menu chevron to allow clicks ([#202](https://github.com/torchbox/django-pattern-library/issues/202), [#205](https://github.com/torchbox/django-pattern-library/pull/205))
 
 ## [1.0.0](https://github.com/torchbox/django-pattern-library/releases/tag/v1.0.0) - 2022-06-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [Unreleased]
-- Tentative support for Django 4.2 ([#212](https://github.com/torchbox/django-pattern-library/issues/212),[#213](https://github.com/torchbox/django-pattern-library/pull/213)).
+- Rewrote tox.ini and pyproject.toml as response to broken CI due to changes in tox ([#218](https://github.com/torchbox/django-pattern-library/issues/218),[#219](https://github.com/torchbox/django-pattern-library/pull/219)).
+- Tentative support for Django 4.2 ([#212](https://github.com/torchbox/django-pattern-library/issues/212),[#219](https://github.com/torchbox/django-pattern-library/pull/219)).
 - Disable pointer events on menu chevron to allow clicks ([#202](https://github.com/torchbox/django-pattern-library/issues/202), [#205](https://github.com/torchbox/django-pattern-library/pull/205))
 
 ## [1.0.0](https://github.com/torchbox/django-pattern-library/releases/tag/v1.0.0) - 2022-06-10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
 ]
 packages = [
     { include = "pattern_library" },
@@ -44,21 +45,30 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-Django = ">=3.2,<4.2"
+Django = ">=3.2,<4.3"
 PyYAML = ">=5.1,<7.0"
 Markdown = "^3.1"
 
-[tool.poetry.dev-dependencies]
-beautifulsoup4 = "^4.8"
-coverage = "^6.2"
-flake8 = "^3.7"
-isort = "^5.10.1"
-mkdocs = "^1.1.2"
-mkdocs-material = "^5.5.14"
-pymdown-extensions = "^8.0"
-mkdocs-git-revision-date-plugin = "^0.3.1"
-mkdocs-redirects = "^1.0.3"
-black = "^22.3.0"
+# A list of all of the dev dependencies, some of which are included in the
+# below `extras`. They can be opted into by apps.
+beautifulsoup4 = { version = "^4.8", optional = true }
+coverage = { version = "^6.2", optional = true }
+flake8 = { version = "^3.7", optional = true }
+isort = { version = "^5.10.1", optional = true}
+mkdocs = { version = "^1.1.2", optional = true}
+mkdocs-material = { version = "^5.5.14", optional = true}
+pymdown-extensions = { version = "^8.0", optional = true}
+mkdocs-git-revision-date-plugin = { version = "^0.3.1", optional = true}
+mkdocs-redirects = { version = "^1.0.3", optional = true}
+black = { version = "^22.3.0", optional = true}
+
+[tool.poetry.extras]
+test = [
+    "beautifulsoup4", "coverage", "flake8",
+    "isort", "mkdocs", "mkdocs-material",
+    "pymdown-extensions", "mkdocs-git-revision-date-plugin",
+    "mkdocs-redirects", "black"
+]
 
 [tool.isort]
 known_first_party = "pattern_library"
@@ -70,5 +80,5 @@ default_section = "THIRDPARTY"
 profile = "black"
 
 [build-system]
-requires = ["poetry>=1.1.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}-dj{32,40,41,main}, lint
+envlist = py{37,38,39,310,311}-dj{32,40,41,42,main}, lint
 skipsdist = true
 
 [testenv]
@@ -15,8 +15,10 @@ deps =
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
     ; Use pre-releases until stable releases are available.
-    ; dj42: Django==4.2a1
+    ; Switch to version range upon stable release.
     ; dj42: Django>=4.2,<4.3
+    dj42: Django==4.2rc1
+
     djmain: https://github.com/django/django/archive/main.zip
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,18 @@
 [tox]
-envlist = py{37,38,39,310,311}-dj{32,40,41,42,main}, lint
-skipsdist = true
+envlist =
+    py{37,38,39,310}-dj32
+    py{38,39,310,311}-dj40
+    py{38,39,310,311}-dj41
+    py{38,39,310,311}-dj42
+    py{310,311}-djmain
+    lint
+isolated_build = True
 
 [testenv]
-whitelist_externals =
+allowlist_externals =
     poetry
-install_command =
-    ./tox_install.sh {packages}
+extras =
+    test
 commands =
     poetry run python -X dev -W error runtests.py
     poetry run django-admin render_patterns --settings=tests.settings.dev --pythonpath=. --dry-run
@@ -17,13 +23,12 @@ deps =
     ; Use pre-releases until stable releases are available.
     ; Switch to version range upon stable release.
     ; dj42: Django>=4.2,<4.3
-    dj42: Django==4.2rc1
-
+    dj42: Django>=4.2rc1,<4.3
     djmain: https://github.com/django/django/archive/main.zip
+
 
 [testenv:lint]
 commands =
-    poetry install -q
     poetry run flake8
     poetry run isort --check --diff .
     poetry run black --check --diff .


### PR DESCRIPTION
## Description

In tox.ini:

- Replace whitelist_externals with allowlist_externals because whitelist_externals is deprecated
- Added isolated_build = True
- Remove install_command where it calls tox_install.sh
- Drop tool.poetry.dev-dependencies and switch to using tool.poetry.extras in order for tox to detect them

In ci.yml
- Because now use tool.poetry.extras so when call `poetry install` need to incldue `—extras ‘test’` as argument

The last 2 points about dropping dev-dependencies and using extras are from https://github.com/orgs/python-poetry/discussions/4307#discussioncomment-1041658

Fixes #212, #214, #215, #216, #218

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
