### PR TITLE
Add Django 4.2 to the testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,19 @@ jobs:
           - python: "3.7"
             toxenv: py37-dj32
           - python: "3.8"
-            toxenv: py38-dj32,py38-dj40,py38-dj41
+            toxenv: py38-dj32,py38-dj40,py38-dj41,py38-dj42
           - python: "3.9"
-            toxenv: py39-dj32,py39-dj40,py39-dj41
+            toxenv: py39-dj32,py39-dj40,py39-dj41,py39-dj42
           - python: "3.10"
             # Skip testing Django 4.0, already tested in previous workflow job.
-            toxenv: py310-dj32,py310-dj41,py310-djmain
+            toxenv: py310-dj32,py310-dj41,py310-dj42,py310-djmain
+          - python: "3.11"
+            toxenv: py311-dj41,py311-dj42,py311-djmain
             # Tentative support for next Python pre-release. For the correct specifier,
             # Check: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json.
-          - python: "3.11.0-beta.2"
-            toxenv: py311-dj41
+            # when django supports py312, then uncomment this
+            # - python: "3.12.0-alpha.6"
+            #   toxenv: py312-dj41
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-
+- Tentative support for Django 4.2 ([#212](https://github.com/torchbox/django-pattern-library/issues/212),[#220](https://github.com/torchbox/django-pattern-library/pull/220)).
 - Disable pointer events on menu chevron to allow clicks ([#202](https://github.com/torchbox/django-pattern-library/issues/202), [#205](https://github.com/torchbox/django-pattern-library/pull/205))
 
 ## [1.0.0](https://github.com/torchbox/django-pattern-library/releases/tag/v1.0.0) - 2022-06-10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
 ]
 packages = [
     { include = "pattern_library" },

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,17 @@
 [tox]
-envlist = py{37,38,39,310,311}-dj{32,40,41,main}, lint
+envlist =
+    py{37,38,39,310}-dj32
+    py{38,39,310,311}-dj40
+    py{38,39,310,311}-dj41
+    py{38,39,310,311}-dj42
+    py{310,311}-djmain
+    lint
 skipsdist = true
 
 [testenv]
-whitelist_externals =
+allowlist_externals =
     poetry
+    ./tox_install.sh
 install_command =
     ./tox_install.sh {packages}
 commands =
@@ -17,6 +24,7 @@ deps =
     ; Use pre-releases until stable releases are available.
     ; dj42: Django==4.2a1
     ; dj42: Django>=4.2,<4.3
+    dj42: Django==4.2rc1
     djmain: https://github.com/django/django/archive/main.zip
 
 [testenv:lint]


### PR DESCRIPTION
## Description

This upgrades the support of Django to 4.2rc1

Also this is similar to #219 but continues to use tox_install.sh.

Fixes #212, #214, #218

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
