### PR TITLE
Fix pattern name URL regex to account for Windows paths with backslash. Fix #222

### DIFF
--- a/pattern_library/urls.py
+++ b/pattern_library/urls.py
@@ -7,14 +7,14 @@ urlpatterns = [
     # UI
     re_path(r"^$", views.IndexView.as_view(), name="index"),
     re_path(
-        r"^pattern/(?P<pattern_template_name>[\w./-]+%s)$"
+        r"^pattern/(?P<pattern_template_name>[\w./-\\]+%s)$"
         % (get_pattern_template_suffix()),
         views.IndexView.as_view(),
         name="display_pattern",
     ),
     # iframe rendering
     re_path(
-        r"^render-pattern/(?P<pattern_template_name>[\w./-]+%s)$"
+        r"^render-pattern/(?P<pattern_template_name>[\w./-\\]+%s)$"
         % (get_pattern_template_suffix()),
         views.RenderPatternView.as_view(),
         name="render_pattern",


### PR DESCRIPTION
## Description

Fixed url pattern regex to account for windows paths 
Fixes # (issue)

https://github.com/torchbox/django-pattern-library/issues/222

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
