### PR TITLE
Use the correct iframe width with resize buttons. Fix #226

### DIFF
--- a/pattern_library/static/pattern_library/src/scss/components/_iframe.scss
+++ b/pattern_library/static/pattern_library/src/scss/components/_iframe.scss
@@ -1,4 +1,5 @@
 .iframe {
+    box-sizing: content-box;
     width: 100%;
     border: 1px solid $light-grey;
     margin: 20px 0;


### PR DESCRIPTION
## Description

As the iframe has a `box-sizing: border-box;` inherited from [_base.scss](https://github.com/torchbox/django-pattern-library/blob/main/pattern_library/static/pattern_library/src/scss/abstracts/_base.scss)  the width is being affected by the border that is being applied here (reducing the real width in 2px). 

Also, it is prune to other errors, as other properties could affect that width (like adding a padding)


Fixes #226

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added an appropriate CHANGELOG entry
