### PR TITLE
Use poetry-core build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,5 +70,5 @@ default_section = "THIRDPARTY"
 profile = "black"
 
 [build-system]
-requires = ["poetry>=1.1.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Description

Pulling in poetry, the CLI tool is unnecessary. Instead poetry-core, the builder
can be used separately like this.

https://github.com/python-poetry/poetry-core#why-is-this-required

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added an appropriate CHANGELOG entry
