### PR TITLE
Make sure /app is always in sys.path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure the project root is on `sys.path` so tests etc. can be run in by Docker Compose ([#233](https://github.com/torchbox/django-pattern-library/issues/233), [#234](https://github.com/torchbox/django-pattern-library/pull/234))
+
 ## [1.0.1](https://github.com/torchbox/django-pattern-library/releases/tag/v1.0.1) - 2023-08-19
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN useradd --create-home dpl && \
     chown -R dpl:dpl /venv/ /app/
 
 ENV PATH=/venv/bin:/home/dpl/.local/bin:$PATH \
+    PYTHONPATH=/app/ \
     VIRTUAL_ENV=/venv/ \
     DJANGO_SETTINGS_MODULE=tests.settings.dev
 


### PR DESCRIPTION
## Description

Ensures `/app/` in the Docker container is always on `sys.path` so we can import the tests, etc.

Fixes #233 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
