### PR TITLE
Avoid duplicating templates when more than one template engine is set up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid duplicating templates when more than one template engine is set up
+
+
 ## [1.5.0](https://github.com/torchbox/django-pattern-library/releases/tag/v1.5.0) - 2025-04-08
 
 ### Added

--- a/pattern_library/utils.py
+++ b/pattern_library/utils.py
@@ -1,6 +1,7 @@
 import operator
 import os
 import re
+from pathlib import Path
 
 from django.conf import settings
 from django.template import TemplateDoesNotExist
@@ -75,9 +76,11 @@ def get_template_dirs():
     template_dirs = [
         d for engines in settings.TEMPLATES for d in engines.get("DIRS", [])
     ]
+    template_dirs_paths = [Path(d).absolute() for d in template_dirs]
     template_app_dirs = get_app_template_dirs("templates")
-    template_dirs += template_app_dirs
-    return template_dirs
+    # Use set to avoid duplicates in case more than one engine is used and
+    # both find the same dirs
+    return list(set(template_dirs_paths).union(set(template_app_dirs)))
 
 
 def get_pattern_config_str(template_name):

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -65,13 +65,13 @@ class TestGetTemplateDirs(SimpleTestCase):
         ]
     )
     def test_get_template_dirs_app_dirs(self):
-        self.assertListEqual(
-            self.get_relative_template_dirs(),
-            [
+        self.assertEqual(
+            set(self.get_relative_template_dirs()),
+            {
                 "django/contrib/auth",
                 "dpl/pattern_library",
                 "dpl/tests",
-            ],
+            },
         )
 
     @override_settings(
@@ -90,15 +90,40 @@ class TestGetTemplateDirs(SimpleTestCase):
         ]
     )
     def test_get_template_dirs_list_dirs(self):
-        self.assertListEqual(
-            self.get_relative_template_dirs(),
-            [
+        self.assertEqual(
+            set(self.get_relative_template_dirs()),
+            {
                 "dpl/tests/test_one",
                 "dpl/tests/test_two",
                 "django/contrib/auth",
                 "dpl/pattern_library",
                 "dpl/tests",
-            ],
+            },
+        )
+
+    @override_settings(
+        TEMPLATES=[
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "APP_DIRS": True,
+                "DIRS": [os.path.join(settings.BASE_DIR, "test_one", "templates")],
+            },
+            {
+                "BACKEND": "django.template.backends.jinja2.Jinja2",
+                "APP_DIRS": True,
+                "DIRS": [os.path.join(settings.BASE_DIR, "test_one", "templates")],
+            },
+        ]
+    )
+    def test_get_template_dirs_with_two_engines(self):
+        self.assertEqual(
+            set(self.get_relative_template_dirs()),
+            {
+                "dpl/tests/test_one",
+                "django/contrib/auth",
+                "dpl/pattern_library",
+                "dpl/tests",
+            },
         )
 
 


### PR DESCRIPTION
## Description

If more than one template engine is used, patterns get duplicated on the menu.

The PR changes the `get_template_dirs` method to make sure each directory is only listed once.

Fixes #264

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
