### PR TITLE
Make template docs the default tab, and change the order of tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Swap position of template "docs" and "source" tabs, and make the "docs" tab the default ([#259](https://github.com/torchbox/django-pattern-library/issues/259))
+
 ### Removed
 
 - Drop support for Python 3.9

--- a/pattern_library/templates/pattern_library/index.html
+++ b/pattern_library/templates/pattern_library/index.html
@@ -39,7 +39,7 @@
 
             <div class="tabbed-content__tabs">
                 <div id="tab-1" class="tabbed-content__item tabbed-content__item--active">
-                    <div class="md">{{ pattern_markdown|safe }}</div>
+                    {% if pattern_markdown %}<div class="md">{{ pattern_markdown|safe }}</div>{% else %}<div class="md">No template doc available.</div>{% endif %}
                 </div>
 
                 <div id="tab-2" class="tabbed-content__item">

--- a/pattern_library/templates/pattern_library/index.html
+++ b/pattern_library/templates/pattern_library/index.html
@@ -25,20 +25,21 @@
         <div class="tabbed-content">
             <ul class="tabbed-content__list">
                 <li class="tabbed-content__heading tabbed-content__heading--active">
-                    <a href="#tab-1">Template source</a>
+                    <a href="#tab-1">Template docs</a>
                 </li>
+
                 <li class="tabbed-content__heading">
                     <a href="#tab-2">Template config</a>
                 </li>
 
                 <li class="tabbed-content__heading">
-                    <a href="#tab-3">Template docs</a>
+                    <a href="#tab-3">Template source</a>
                 </li>
             </ul>
 
             <div class="tabbed-content__tabs">
                 <div id="tab-1" class="tabbed-content__item tabbed-content__item--active">
-                    <pre><code class="code django">{{ pattern_source }}</code></pre>
+                    <div class="md">{{ pattern_markdown|safe }}</div>
                 </div>
 
                 <div id="tab-2" class="tabbed-content__item">
@@ -46,7 +47,7 @@
                 </div>
 
                 <div id="tab-3" class="tabbed-content__item">
-                    <div class="md">{{ pattern_markdown|safe }}</div>
+                    <pre><code class="code django">{{ pattern_source }}</code></pre>
                 </div>
             </div>
         </div>

--- a/pattern_library/templates/pattern_library/index.html
+++ b/pattern_library/templates/pattern_library/index.html
@@ -39,7 +39,7 @@
 
             <div class="tabbed-content__tabs">
                 <div id="tab-1" class="tabbed-content__item tabbed-content__item--active">
-                    {% if pattern_markdown %}<div class="md">{{ pattern_markdown|safe }}</div>{% else %}<div class="md">No template doc available.</div>{% endif %}
+{% if pattern_markdown %}<div class="md">{{ pattern_markdown|safe }}</div>{% else %}<div class="md">No template doc available.</div>{% endif %}
                 </div>
 
                 <div id="tab-2" class="tabbed-content__item">


### PR DESCRIPTION
## Description

This does three things:
1. Changes order of tabs so "Docs" comes first, "Source" comes last (effectively swapping these two tabs).
2. Makes the "Docs" tab the default tab.
3. Adds a "No template doc available" message if there is no .md file or the file is empty.

Number 3 is not part of the original request but I think it makes sense, I'd like a review of that thought - my line of thinking was that "template source" is *always* set to something, so you never get an empty tab. Adding a message makes it clear why there is nothing there for the docs. If you don't agree, I committed the change separately so its easy to revert it.

Note: I have not as yet screenshotted a replacement for `docs/images/pattern-library-screenshot.webp` and `docs/images/getting-started/getting-started-complete.png`, but if needed I can do that before the PR is merged.

Fixes  #259 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
