### PR TITLE
Add blocks to base.html and index.html to make them easier to extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add blocks to base.html and index.html to make them easier to extend ([#276](https://github.com/torchbox/django-pattern-library/issues/276))
+
 ### Removed
 
 - Drop support for Python 3.9

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -198,3 +198,51 @@ context:
 And that’s it! Our `quote_block` should finally appear in the pattern library, along with its rendering with this mock data.
 
 ![Screenshot of the quote_block template](images/getting-started/getting-started-complete.png)
+
+## Customisation
+
+If you need to make any customisations to the pattern library markup, some custom blocks are provided to make this easier and avoid you having to copy the entire template file into your project.
+
+### In base.html:
+
+Allow custom JavaScript or JavaScript files:
+
+```html
+{% block custom_extra_js %} {% endblock %}
+```
+
+Allow custom CSS or CSS files:
+
+```html
+{% block custom_extra_css %} {% endblock %}
+```
+
+Allow custom navigation items in the sidebar:
+
+```html
+{% block custom_nav_item %} {% endblock %}
+```
+
+Allow extra sidebar content after the navigation:
+
+```html
+{% block custom_sidebar_content %} {% endblock %}
+```
+
+### In index.html
+
+Allow extra markup in the pattern header area:
+
+```html
+{% block custom_pattern_header %} {% endblock %}
+```
+
+Allow extra tab items:
+
+```html
+{% block custom_tab_heading %} {% endblock %}
+```
+
+```html
+{% block custom_tab_content %} {% endblock %}
+```

--- a/pattern_library/templates/pattern_library/base.html
+++ b/pattern_library/templates/pattern_library/base.html
@@ -9,6 +9,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>♻️</text></svg>"/>
     <script type="text/javascript" src="{% static 'pattern_library/dist/bundle.js' %}"></script>
+    {% block custom_extra_js %}
+    {% endblock %}
+    {% block custom_extra_css %}
+    {% endblock %}
 </head>
 
 <body class="body">
@@ -40,9 +44,13 @@
                         {% include "pattern_library/pattern_group.html" with groups=pattern_templates.template_groups %}
                     </li>
                     {% endfor %}
+                    {% block custom_nav_item %}
+                    {% endblock %}
                 </ul>
             </nav>
         </div>
+        {% block custom_sidebar_content %}
+        {% endblock %}
     </aside>
     <main class="main">
         {% block content %}{% endblock %}

--- a/pattern_library/templates/pattern_library/index.html
+++ b/pattern_library/templates/pattern_library/index.html
@@ -20,6 +20,9 @@
             </div>
         </div>
 
+        {% block custom_pattern_header %}
+        {% endblock %}
+
         <iframe class="iframe js-iframe is-animatable" src="{% url 'pattern_library:render_pattern' pattern_template_name=pattern_template_name %}" title="Iframe pattern"></iframe>
 
         <div class="tabbed-content">
@@ -34,6 +37,9 @@
                 <li class="tabbed-content__heading">
                     <a href="#tab-3">Template docs</a>
                 </li>
+
+                {% block custom_tab_heading %}
+                {% endblock %}
             </ul>
 
             <div class="tabbed-content__tabs">
@@ -48,6 +54,9 @@
                 <div id="tab-3" class="tabbed-content__item">
                     <div class="md">{{ pattern_markdown|safe }}</div>
                 </div>
+
+                {% block custom_tab_content %}
+                {% endblock %}
             </div>
         </div>
 


### PR DESCRIPTION
## Description

Add blocks to base.html and index.html to make them easier to extend

Fixes # (issue)

https://github.com/torchbox/django-pattern-library/issues/276

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added an appropriate CHANGELOG entry
